### PR TITLE
Fix/update model insert

### DIFF
--- a/src/matchbox/server/postgresql/utils/insert.py
+++ b/src/matchbox/server/postgresql/utils/insert.py
@@ -126,25 +126,28 @@ def insert_model(
     """
     logic_logger.info(f"[{model}] Registering model")
     with Session(engine) as session:
-        model_hash = list_to_value_ordered_hash([left.hash, right.hash, bytes(model, encoding="utf-8")])
+        model_hash = list_to_value_ordered_hash(
+            [left.hash, right.hash, bytes(model, encoding="utf-8")]
+        )
 
         # Check if model exists
         exists_stmt = select(Models).where(Models.hash == model_hash)
         exists = session.scalar(exists_stmt) is not None
 
         # Upsert new model
-        stmt = insert(Models).values(
-            hash=model_hash,
-            type=ModelType.MODEL.value,
-            name=model,
-            description=description,
-            truth=1.0,
-        ).on_conflict_do_update(
-            index_elements=['hash'],
-            set_={
-                'name': model,
-                'description': description
-            }
+        stmt = (
+            insert(Models)
+            .values(
+                hash=model_hash,
+                type=ModelType.MODEL.value,
+                name=model,
+                description=description,
+                truth=1.0,
+            )
+            .on_conflict_do_update(
+                index_elements=["hash"],
+                set_={"name": model, "description": description},
+            )
         )
 
         session.execute(stmt)

--- a/test/server/test_adapter.py
+++ b/test/server/test_adapter.py
@@ -220,6 +220,13 @@ class TestMatchboxBackend:
 
         assert self.backend.models.count() == model_count + 3
 
+        # Test model upsert
+        self.backend.insert_model(
+            "link_1", left="dedupe_1", right="dedupe_2", description="Test upsert"
+        )
+
+        assert self.backend.models.count() == model_count + 3
+
     def test_model_get_probabilities(self):
         """Test that a model's ProbabilityResults can be retrieved."""
         self.setup_database("dedupe")


### PR DESCRIPTION
# Context

`insert_model` currently only hashes on the parent model’s hashes and nothing else, so you can’t have two different models that work on the same parents.

It also runs with every `to_matchbox` call with `Results`, and currently this means you can only do that once before it errors. Adding upserts functionality will fix.

## Changes proposed in this pull request

* Add name to `list_to_value_ordered_hash` in `insert_model`
* Allows `insert_model` to upsert when the hash is the same

## Guidance to review

* Check you're happy with the new unit tests

## Relevant links

* SQLAlchemy [postgres upsert documentation](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#insert-update-returning)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes