### PR TITLE
Create database added to API startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
   api:
     build:
       context: .
+      args:
+        ENV_FILE: dev_docker.env
       dockerfile: src/matchbox/server/Dockerfile
     ports:
       - "8000:8000"

--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -17,7 +17,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --all-extras --no-install-project --no-dev
 
-COPY ./environments/dev_docker.env /code/.env
+ARG ENV_FILE
+COPY ./environments/$ENV_FILE /code/.env
 COPY ./uv.lock /code/uv.lock
 COPY ./pyproject.toml /code/pyproject.toml
 COPY ./src/matchbox /code/src/matchbox

--- a/src/matchbox/server/api.py
+++ b/src/matchbox/server/api.py
@@ -1,6 +1,6 @@
 from contextlib import asynccontextmanager
 from enum import StrEnum
-from typing import Annotated
+from typing import Annotated, AsyncGenerator
 
 from dotenv import find_dotenv, load_dotenv
 from fastapi import Depends, FastAPI, HTTPException
@@ -14,10 +14,9 @@ load_dotenv(dotenv_path)
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     get_backend()
     yield
-    pass
 
 
 app = FastAPI(

--- a/src/matchbox/server/api.py
+++ b/src/matchbox/server/api.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from enum import StrEnum
 from typing import Annotated
 
@@ -12,9 +13,17 @@ dotenv_path = find_dotenv(usecwd=True)
 load_dotenv(dotenv_path)
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    get_backend()
+    yield
+    pass
+
+
 app = FastAPI(
     title="matchbox API",
     version="0.2.0",
+    lifespan=lifespan,
 )
 
 


### PR DESCRIPTION
# Context

## Changes proposed in this pull request

* Environment file added as an argument to the API container startup. 
* Lifespan function added in app to explicitly create the matchbox database when initialising the API.

## Guidance to review

Is the lifespan function necessary?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
