### PR TITLE
Fix/add signature to index cluster hash

### DIFF
--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -267,7 +267,11 @@ class Source(BaseModel):
             {
                 "source_pk": grouped_keys,
                 "hash": pa.array(
-                    [hash_data(d) for d in grouped_data.to_pylist()], type=pa.binary()
+                    [
+                        hash_data(" ".join([d, self.signature.hex()]))
+                        for d in grouped_data.to_pylist()
+                    ],
+                    type=pa.binary(),
                 ),
             }
         )

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -262,15 +262,13 @@ class Source(BaseModel):
         grouped = raw_result.group_by("raw").aggregate([("source_pk", "list")])
         grouped_data = grouped["raw"]
         grouped_keys = grouped["source_pk_list"]
+        signature_hex = self.signature.hex()
 
         return pa.table(
             {
                 "source_pk": grouped_keys,
                 "hash": pa.array(
-                    [
-                        hash_data(" ".join([d, self.signature.hex()]))
-                        for d in grouped_data.to_pylist()
-                    ],
+                    [hash_data(d + signature_hex) for d in grouped_data.to_pylist()],
                     type=pa.binary(),
                 ),
             }

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -259,16 +259,18 @@ class Source(BaseModel):
         )
 
         raw_result = sql_to_df(slct_stmt, self._engine, "arrow")
+
         grouped = raw_result.group_by("raw").aggregate([("source_pk", "list")])
-        grouped_data = grouped["raw"]
+        grouped_data = pa.compute.binary_join_element_wise(
+            grouped["raw"], self.signature.hex(), " "
+        )
         grouped_keys = grouped["source_pk_list"]
-        signature_hex = self.signature.hex()
 
         return pa.table(
             {
                 "source_pk": grouped_keys,
                 "hash": pa.array(
-                    [hash_data(d + signature_hex) for d in grouped_data.to_pylist()],
+                    [hash_data(d) for d in grouped_data.to_pylist()],
                     type=pa.binary(),
                 ),
             }


### PR DESCRIPTION
# Context

## Changes proposed in this pull request

This PR add the the table signature to the cluster hash in order to avoid clashes where cluster hashes from different sources are identical. The changes include:
 - Addition of source signature in the to_hash function. 

## Guidance to review

This may decrease the speed of indexing. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
