### PR TITLE
Split Dockerfile to stages for dev and prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       args:
         ENV_FILE: dev_docker.env
       dockerfile: src/matchbox/server/Dockerfile
+      target: dev
     ports:
       - "8000:8000"
     depends_on:

--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -1,5 +1,5 @@
 # connectorx won't work on ARM or python-alpine
-FROM --platform=amd64 python:3.11
+FROM --platform=amd64 python:3.11 AS base
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
@@ -18,7 +18,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --all-extras --no-install-project --no-dev
 
 ARG ENV_FILE
-COPY ./environments/$ENV_FILE /code/.env
 COPY ./uv.lock /code/uv.lock
 COPY ./pyproject.toml /code/pyproject.toml
 COPY ./src/matchbox /code/src/matchbox
@@ -31,6 +30,18 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Place executables in the environment at the front of the path
 ENV PATH="/code/.venv/bin:$PATH"
 
-# Uses `fastapi dev` to enable hot-reloading when the `watch` sync occurs
-# Uses `--host 0.0.0.0` to allow access from outside the container
+
+# Local development stage: with locally-specified environment variables and hot reloading
+
+FROM base AS dev
+
+COPY ./environments/$ENV_FILE /code/.env
 CMD ["fastapi", "dev", "--host", "0.0.0.0", "src/matchbox/server/api"]
+
+
+# Production stage: no environment variables (they come from the infrastructure) and no hot reloading
+
+FROM base AS prod
+
+# Uses `--host 0.0.0.0` to allow access from outside the container
+CMD ["fastapi", "run", "--host", "0.0.0.0", "src/matchbox/server/api"]


### PR DESCRIPTION
# Context

We're deploying Matchbox to AWS, and so making changes that support that.

## Changes proposed in this pull request

This splits the Dockerfile into stages

- A "base" stage that has the bulk of the the command/config
- A "dev" stage that has configuration for local development
- A "prod" stage that has the configuration for deployment

The dev and prod stages are kept deliberately minimal to try to make sure that the local dev environment is as close to production as possible. The key differences between them are that the "prod" stage uses the run mode of fastapi compared to the "dev" mode in the dev stage, also "prod" does not contain any environment variables, while "dev" copies them in from the local filesystem - something we definitely want to avoid when making a production image.

## Guidance to review

Looking through the changes and running matchbox locally should be enough - this should ensure existing behaviour is preserved which is the most important thing. There may be further changes after deployment, but we can determine those later.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation