### PR TITLE
Run the Datadog agent for local dev and pass traces to it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.*.env
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@ To install the full package, including the server features:
 pip install "matchbox[server] @ git+ssh://git@github.com/uktrade/matchbox.git"
 ```
 
+## Running the server locally
+
+To run the server locally, run:
+
+```bash
+docker compose up --build
+```
+
+## Running the server locally with Datadog (monitoring) integration
+
+1. Run:
+
+   ```
+   cp ./environments/datadog-agent-private-sample.env ./environments/.datadog-agent-private.env
+   ```
+
+2. Populate the newly-created ` ./environments/.datadog-agent-private.env` with a Datadog API key.
+
+
+3. Run the server using:
+
+   ```bash
+   docker compose --profile monitoring up --build
+   ```
+
+
 ## Use cases
 
 ### Data architects and engineers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+  datadog-agent:
+    image: datadog/agent:7
+    profiles:
+      - monitoring
+    env_file:
+      - environments/datadog-agent-public.env
+      - environments/.datadog-agent-private.env
   api:
     build:
       context: .
@@ -45,12 +52,20 @@ services:
         ENV_FILE: dev_docker.env
       dockerfile: src/matchbox/server/Dockerfile
       target: dev
+    environment:
+      DD_AGENT_HOST: datadog-agent
     ports:
       - "8000:8000"
     depends_on:
-      - matchbox-postgres
-      - matchbox-storage
-    
+      matchbox-postgres:
+        condition: service_started
+        required: true
+      matchbox-storage:
+        condition: service_started
+        required: true
+      datadog-agent:
+        condition: service_healthy
+        required: false
     develop:
       # https://docs.docker.com/compose/file-watch/#compose-watch-versus-bind-mounts
       watch:

--- a/environments/datadog-agent-private-sample.env
+++ b/environments/datadog-agent-private-sample.env
@@ -1,0 +1,6 @@
+# ***DO NOT*** put a real API key in this file when named datadog-agent-private-sample.env, because
+# it risks getting committed and pushed to GitHub
+#
+# Intead, to test integration with Datadog, copy this file to .datadog-agent-private.env and set
+# the API only in that file only
+DD_API_KEY=

--- a/environments/datadog-agent-public.env
+++ b/environments/datadog-agent-public.env
@@ -1,0 +1,18 @@
+# Sets tags attached to logs/metrics/errors
+DD_SERVICE=matchbox
+DD_ENV=local
+
+# What integrations are enabled
+DD_APM_ENABLED=true
+DD_LOGS_ENABLED=true
+DD_PROFILING_ENABLED=true
+DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED=true
+
+# Allows connections not from localhost to the agent (crucial when running as a sidecar container)
+DD_APM_NON_LOCAL_TRAFFIC=true
+
+# Where logs and traces are sent to
+DD_SITE=datadoghq.eu
+
+# The hostname of the agent itself (which is the service name when running via docker compose)
+DD_HOSTNAME=datadog-agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 server = [
     "boto3>=1.35.99",
+    "ddtrace>=3.2.1",
     "fastapi[standard]>=0.115.0,<0.116.0",
     "pg-bulk-ingest>=0.0.54",
     "python-multipart>=0.0.18",

--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -30,6 +30,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Place executables in the environment at the front of the path
 ENV PATH="/code/.venv/bin:$PATH"
 
+ENTRYPOINT ["ddtrace-run"]
+
 
 # Local development stage: with locally-specified environment variables and hot reloading
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,13 @@ version = 1
 revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '4' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.13' and python_full_version < '4' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
     "python_full_version < '3.12' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.12' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '4' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and python_full_version < '4' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
     "python_full_version < '3.12' and platform_python_implementation == 'PyPy'",
 ]
 
@@ -141,6 +145,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/bc/10e9e5d5cdda0728e79ca3fba75d7586be737660a97e3f1e2c8915a9185c/botocore_stubs-1.36.5.tar.gz", hash = "sha256:e6057f127ba01a7770b671af924cc65a214d0c14a2ae054eb16e3ea5ad475372", size = 41200 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f3/f7ec4bd4561205e44b466e45194468e4f70637bc57788af95a4557042117/botocore_stubs-1.36.5-py3-none-any.whl", hash = "sha256:d3c5c0841fcf8820a8cb0690fa0eeb0a64c72104ba892cc56dc0b9515872b5dd", size = 64003 },
+]
+
+[[package]]
+name = "bytecode"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/9c/f7e0b14b0a93e4b312de0897aec38e2d74a3b02bcc047ab046be98a617d9/bytecode-0.16.1.tar.gz", hash = "sha256:8fbbb637c880f339e564858bc6c7984ede67ae97bc71343379a535a9a4baf398", size = 102863 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/6c/d7c50fec12a2f648c06021eaa833b826e069bc767719cb099eaf87c20fda/bytecode-0.16.1-py3-none-any.whl", hash = "sha256:1d4b61ed6bade4bff44127c8283bef8131a664ce4dbe09d64a88caf329939f35", size = 41943 },
 ]
 
 [[package]]
@@ -451,6 +464,52 @@ wheels = [
 ]
 
 [[package]]
+name = "ddtrace"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode" },
+    { name = "envier" },
+    { name = "legacy-cgi", marker = "python_full_version >= '3.13'" },
+    { name = "opentelemetry-api" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/ed/36bd8714478466585bde71292b4daf5ad5fa9fdcd27a7757f5fae571a6bb/ddtrace-3.2.1.tar.gz", hash = "sha256:d7fd33aa80131bc7cc619cd5bc63395c8ae2566aa49e5877d8d4295044b07ddd", size = 5859702 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/cd/6ef50662d46630e469484c482e513fb987fd3cdc2c841c6dcf8ace9d07af/ddtrace-3.2.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4c463262a5c2381dae3776f51a335310e2474deaf863997f4f0393ec2fcb6442", size = 7204708 },
+    { url = "https://files.pythonhosted.org/packages/a3/f5/ddb1951300ab288593f5b36da2fa0fc509613aa29c1446527428df313b17/ddtrace-3.2.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:9669924ef069a9f85c424837d73fb13377fef67d2926e7f68f06fef4467f7352", size = 3383295 },
+    { url = "https://files.pythonhosted.org/packages/50/d6/3a2c2087dbd5e5caa003c03e17431c65055c7f3ce56fb1a1fa2e42271296/ddtrace-3.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8d0d3a4dd0dcff2af95666235838af29eae8fd489df8938527ad7d5f40db93c", size = 6183979 },
+    { url = "https://files.pythonhosted.org/packages/43/29/d9e9887f28cc03a9bc27e8eb1a32e4d956f541af8048e3a19885d773528f/ddtrace-3.2.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:793da357c0121ee8b9203d776e577d55ff9dd5c1ec827fd669bcc35058d7278b", size = 2978384 },
+    { url = "https://files.pythonhosted.org/packages/e3/04/841a9d3ece95f72c174e8d95285e68b07626e0c258203002e98dd5981b3f/ddtrace-3.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7cd268fc09e7183e3457963a1534331fd838b890da827db7e5ef992e6bd5e96", size = 6530356 },
+    { url = "https://files.pythonhosted.org/packages/bd/b6/658c8ea37296bbbcf526c9f624e35f2b3e8f77e34e7e61512ae915d7424d/ddtrace-3.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:62c3aef2b677299947fefb899b914158a4f3af63cefb6f7c4d9d2cf06865ce44", size = 7174653 },
+    { url = "https://files.pythonhosted.org/packages/72/cd/57c129ec32d5868c1f8836b8e17218c404429708ca4273ac7a65a4456735/ddtrace-3.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:90c641c97ad10475723fd12c5708247c2a796a4ccd5a27195502993b3baeb513", size = 4034061 },
+    { url = "https://files.pythonhosted.org/packages/41/01/cc74be71327bc737cfae4381498b00c185bcfe578adc674e17d6963b7fba/ddtrace-3.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b3852a62155fe0cc500c7a633cb76d3c14bf53e96d9c3936a0d24a22cee22d03", size = 7574359 },
+    { url = "https://files.pythonhosted.org/packages/a9/0d/1e6b9999792dd60bdef62b7f99f884ec2df83113921a97ad8f6f615e3c5f/ddtrace-3.2.1-cp311-cp311-win32.whl", hash = "sha256:78b6683c3d8cbb3d1048f6d7742b12749790abfd6a24ed07d35c61c171167617", size = 3226499 },
+    { url = "https://files.pythonhosted.org/packages/3e/79/99f35a867beafb6b8aff41d54f26846c5dda6554c42c0945ec305e18553d/ddtrace-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:e28337b86e0dcb4c2573248bcbc6706406a2fa496f772495609594f5a50e7003", size = 3458948 },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/729382becc05d2d5bbb9a746354d2432f06d02311f2f483a54ee78e831c8/ddtrace-3.2.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:316f31a4354ab92208b46ed46df9009726831982b072ed79d7f1f411ac6a10af", size = 7205084 },
+    { url = "https://files.pythonhosted.org/packages/bc/bc/271a948ca7b40599b9765902cac476f2b4dd16168e536c1eac2c5380086c/ddtrace-3.2.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:4ae996fbe7c1e3a345b9dce96a030801597fec14b8284574252b2c4dc45a802d", size = 3382206 },
+    { url = "https://files.pythonhosted.org/packages/c5/91/aa0aa7e03354a07ad0e4b1b59c0cc6b858535237155d74d97eac08a1aba6/ddtrace-3.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa39e9587b81c5d342166b9b1b9ea6751954f89324111d52984d9e1cffca4e57", size = 6153447 },
+    { url = "https://files.pythonhosted.org/packages/77/ca/c513964a20e9cc609213e44f1573509d6d4fc80cb380568c6170eaa535c7/ddtrace-3.2.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2beda81f25dad61cb657188f92199c603ee3aef5d9a53a2bf24e4cf2620e699", size = 2945854 },
+    { url = "https://files.pythonhosted.org/packages/00/2c/9a3819da9856193fa5d3d7f77746b706405f8240beed3131e08fd1c5d8f0/ddtrace-3.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fd86d1d47a5f82bb2bda73d339ec434427c5fcb2d259f825d18b097fc2fa3e1", size = 6501284 },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/5854cb722697d92644fc98e5d56ff0d6c449f8eb88c6ffb334f28da48c5b/ddtrace-3.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2cd1febea180a494e67ae0388055f3aaa8f63cb090dcf1ce4c3054c2162e05d1", size = 7139495 },
+    { url = "https://files.pythonhosted.org/packages/a2/7e/2eea88f9d2b52c58501be43fbb6889340bb1852f1d51db61bdc30bd9c662/ddtrace-3.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f8964c3cf0c3ef8dd066323b4ed0fbe561ca56f4a0bbe591b5e8e65411cc955f", size = 4000932 },
+    { url = "https://files.pythonhosted.org/packages/b1/5f/3256fba66f276d6d2c6361d2bbc40c3a6ac4e0f46579487b6d2001e85d24/ddtrace-3.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6a8ca3d670f4c3a873f24fcfb25f9324193b361edb57bbeadc3b90257a3494c2", size = 7538451 },
+    { url = "https://files.pythonhosted.org/packages/5a/f9/8fa3c217250c86079cf3938cac2d9ffcbec365bab856fa5ce6c7ad0b4e25/ddtrace-3.2.1-cp312-cp312-win32.whl", hash = "sha256:c9ffa96777be82566c990a30216aac00ff84b256d7d0a428ed4a63e4666b6c3e", size = 3213523 },
+    { url = "https://files.pythonhosted.org/packages/2b/3d/55a2d032e5b2c9c6f73ccf1b1d95b6593f6ac246513402c13609916e0500/ddtrace-3.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:c2d6c34ed0f7986e9afbd8c991bb4e7049cc5631837708b400dd1c6b108058f9", size = 3448934 },
+    { url = "https://files.pythonhosted.org/packages/19/32/d6c46de1f969ad796ea62cdeeb539555f9aa2ca726c652c1c2ffffdcc695/ddtrace-3.2.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8db2b0aa025ac50b1a4516bdd722ede4a0d70d7c31df7b4ca0842aadfacc8276", size = 7152877 },
+    { url = "https://files.pythonhosted.org/packages/b9/03/9cc44f01595f9f2b9106a3474e113383b5ee6b24e5a585a3ac7ca6305edc/ddtrace-3.2.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:65715768745d609e88d77e7a843477dd8e08da382f6058672210c412924d83af", size = 3371976 },
+    { url = "https://files.pythonhosted.org/packages/98/ea/b59ff450368e68819faf70063d0dab0cbe32ad5f8c3def173fc75f56b236/ddtrace-3.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:003b5de6e28224129e8ba103bd8de26e7571b8c5a9141fdc70f91ad4b15fb4a0", size = 6108237 },
+    { url = "https://files.pythonhosted.org/packages/37/3b/851ecc9113d317fad05b2cfeb0cba1180e05870025f4ea45b1a99418d760/ddtrace-3.2.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28a05aaa595e763ce7c46a4d186da2314c795ed7311efe506a58760f77ce3d13", size = 2936222 },
+    { url = "https://files.pythonhosted.org/packages/07/11/605f43b0a6904e569ec48684fc7ed66afa2ea51f40ed335d42dc992098f6/ddtrace-3.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530cdd0570c5a5c9df420924f992800e90fcb5f556c1a2cd6d83ee4c3356072d", size = 6456926 },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/0c5b7e12400b9c6d834c2975dec0dd3feda7540584fd87ce2421be25e5f6/ddtrace-3.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c38fa59a6e999c7a95c508f3dd020a74173c77ca19517a2257394d7b4329331f", size = 7095632 },
+    { url = "https://files.pythonhosted.org/packages/7a/bb/3f8ab4beee67c98c5bcd16e718a15970d4c542bc2bd1b65d018563c68103/ddtrace-3.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:92de3eed2d2a3ed58a75ad8f44c2897614b9c905dba26b0d29989f849069896e", size = 3998058 },
+    { url = "https://files.pythonhosted.org/packages/1f/75/768ad9c141a3bcd90af316182f81454fd3ca24ca23030ffa97c4eb554694/ddtrace-3.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:157617ee0a8a7a7dd55c9e0e293c8a9f01bc0cbeddc8f36e61d2ce0e95a04be3", size = 7495424 },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.12"
 source = { registry = "https://pypi.org/simple" }
@@ -478,6 +537,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/0c/8d907af351aa16b42caae42f9d6aa37b900c67308052d10fdce809f8d952/decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330", size = 35016 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186", size = 9073 },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998 },
 ]
 
 [[package]]
@@ -556,6 +627,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981ae4ca79ea40384becc868bfae97fd1c942bb3a001b1/email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7", size = 48967 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", hash = "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631", size = 33521 },
+]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e7/4fe4d3f6e21213cea9bcddc36ba60e6ae4003035f9ce8055e6a9f0322ddb/envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9", size = 10063 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/e9/30493b1cc967f7c07869de4b2ab3929151a58e6bb04495015554d24b61db/envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9", size = 10638 },
 ]
 
 [[package]]
@@ -847,6 +927,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e", size = 26971 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1082,6 +1174,15 @@ wheels = [
 ]
 
 [[package]]
+name = "legacy-cgi"
+version = "2.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2e/e1860989bc6cfdecba66db37f2f783636b97a1248ac25fbe864b6e931c22/legacy_cgi-2.6.2.tar.gz", hash = "sha256:9952471ceb304043b104c22d00b4f333cac27a6abe446d8a528fc437cf13c85f", size = 24794 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/cd/54d1fd92d7f6aca9523d8583052e00b273bdfe28aa7fd54a3a5759dab05e/legacy_cgi-2.6.2-py3-none-any.whl", hash = "sha256:a7b83afb1baf6ebeb56522537c5943ef9813cf933f6715e88a803f7edbce0bff", size = 19572 },
+]
+
+[[package]]
 name = "markdown"
 version = "3.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1176,6 +1277,7 @@ dependencies = [
 [package.optional-dependencies]
 server = [
     { name = "boto3" },
+    { name = "ddtrace" },
     { name = "fastapi", extra = ["standard"] },
     { name = "pg-bulk-ingest" },
     { name = "python-multipart" },
@@ -1213,6 +1315,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'server'", specifier = ">=1.35.99" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "connectorx", specifier = ">=0.3.3" },
+    { name = "ddtrace", marker = "extra == 'server'", specifier = ">=3.2.1" },
     { name = "duckdb", specifier = ">=1.1.1" },
     { name = "faker", specifier = ">=36.1.1" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.115.0,<0.116.0" },
@@ -1568,6 +1671,19 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "importlib-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/89/9d80fa1265a25306b5d9b2707ef09094a6dda9feeac2ee159d5a214f989c/opentelemetry_api-1.31.0.tar.gz", hash = "sha256:d8da59e83e8e3993b4726e4c1023cd46f57c4d5a73142e239247e7d814309de1", size = 63853 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/87/5413da9dd80d66ff86205bbd08a9cf69165642565c00cfce6590e0e82980/opentelemetry_api-1.31.0-py3-none-any.whl", hash = "sha256:145b72c6c16977c005c568ec32f4946054ab793d8474a17fd884b0397582c5f2", size = 65099 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1789,6 +1905,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab", size = 429087 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198", size = 387816 },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/6a/2629bb3529e5bdfbd6c4608ff5c7d942cd4beae85793f84ba543aab2548a/protobuf-6.30.0.tar.gz", hash = "sha256:852b675d276a7d028f660da075af1841c768618f76b90af771a8e2c29e6f5965", size = 429239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/76/8b1cbf762d98b09fcb29bbc6eca97dc6e1cd865b97a49c443aa23f1a9f82/protobuf-6.30.0-cp310-abi3-win32.whl", hash = "sha256:7337d76d8efe65ee09ee566b47b5914c517190196f414e5418fa236dfd1aed3e", size = 419141 },
+    { url = "https://files.pythonhosted.org/packages/57/50/2ea2fb4533321438f5106723c70c303529ba184540e619ebe75e790d402e/protobuf-6.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:9b33d51cc95a7ec4f407004c8b744330b6911a37a782e2629c67e1e8ac41318f", size = 430995 },
+    { url = "https://files.pythonhosted.org/packages/a1/7d/a7dfa7aa3deda114920b1ed57c0026e85a976e74658db2784a0443510252/protobuf-6.30.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:52d4bb6fe76005860e1d0b8bfa126f5c97c19cc82704961f60718f50be16942d", size = 417570 },
+    { url = "https://files.pythonhosted.org/packages/11/87/a9c7b020c4072dc34e3a2a3cde69366ffc623afff0e7f10f4e5275aaec01/protobuf-6.30.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:7940ab4dfd60d514b2e1d3161549ea7aed5be37d53bafde16001ac470a3e202b", size = 317310 },
+    { url = "https://files.pythonhosted.org/packages/95/66/424db2262723781dc94208ff9ce201df2f44f18a46fbff3c067812c6b5b9/protobuf-6.30.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:d79bf6a202a536b192b7e8d295d7eece0c86fbd9b583d147faf8cfeff46bf598", size = 316203 },
+    { url = "https://files.pythonhosted.org/packages/51/6f/21c2b7de96c3051f847a4a88a12fdf015ed6b7d50fc131fb101a739bd7a5/protobuf-6.30.0-py3-none-any.whl", hash = "sha256:e5ef216ea061b262b8994cb6b7d6637a4fb27b3fb4d8e216a6040c0b93bd10d7", size = 167054 },
 ]
 
 [[package]]
@@ -2757,7 +2887,9 @@ name = "urllib3"
 version = "1.26.20"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '4' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and python_full_version < '4' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
     "python_full_version < '3.12' and platform_python_implementation == 'PyPy'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380 }
@@ -2770,7 +2902,9 @@ name = "urllib3"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '4' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.13' and python_full_version < '4' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
     "python_full_version < '3.12' and platform_python_implementation != 'PyPy'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
@@ -2991,10 +3125,72 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "1.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/f7/a2aab2cbc7a665efab072344a8949a71081eed1d2f451f7f7d2b966594a2/wrapt-1.17.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58", size = 53308 },
+    { url = "https://files.pythonhosted.org/packages/50/ff/149aba8365fdacef52b31a258c4dc1c57c79759c335eff0b3316a2664a64/wrapt-1.17.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4db983e7bca53819efdbd64590ee96c9213894272c776966ca6306b73e4affda", size = 38488 },
+    { url = "https://files.pythonhosted.org/packages/65/46/5a917ce85b5c3b490d35c02bf71aedaa9f2f63f2d15d9949cc4ba56e8ba9/wrapt-1.17.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9abc77a4ce4c6f2a3168ff34b1da9b0f311a8f1cfd694ec96b0603dff1c79438", size = 38776 },
+    { url = "https://files.pythonhosted.org/packages/ca/74/336c918d2915a4943501c77566db41d1bd6e9f4dbc317f356b9a244dfe83/wrapt-1.17.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b929ac182f5ace000d459c59c2c9c33047e20e935f8e39371fa6e3b85d56f4a", size = 83776 },
+    { url = "https://files.pythonhosted.org/packages/09/99/c0c844a5ccde0fe5761d4305485297f91d67cf2a1a824c5f282e661ec7ff/wrapt-1.17.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f09b286faeff3c750a879d336fb6d8713206fc97af3adc14def0cdd349df6000", size = 75420 },
+    { url = "https://files.pythonhosted.org/packages/b4/b0/9fc566b0fe08b282c850063591a756057c3247b2362b9286429ec5bf1721/wrapt-1.17.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7ed2d9d039bd41e889f6fb9364554052ca21ce823580f6a07c4ec245c1f5d6", size = 83199 },
+    { url = "https://files.pythonhosted.org/packages/9d/4b/71996e62d543b0a0bd95dda485219856def3347e3e9380cc0d6cf10cfb2f/wrapt-1.17.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:129a150f5c445165ff941fc02ee27df65940fcb8a22a61828b1853c98763a64b", size = 82307 },
+    { url = "https://files.pythonhosted.org/packages/39/35/0282c0d8789c0dc9bcc738911776c762a701f95cfe113fb8f0b40e45c2b9/wrapt-1.17.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1fb5699e4464afe5c7e65fa51d4f99e0b2eadcc176e4aa33600a3df7801d6662", size = 75025 },
+    { url = "https://files.pythonhosted.org/packages/4f/6d/90c9fd2c3c6fee181feecb620d95105370198b6b98a0770cba090441a828/wrapt-1.17.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9a2bce789a5ea90e51a02dfcc39e31b7f1e662bc3317979aa7e5538e3a034f72", size = 81879 },
+    { url = "https://files.pythonhosted.org/packages/8f/fa/9fb6e594f2ce03ef03eddbdb5f4f90acb1452221a5351116c7c4708ac865/wrapt-1.17.2-cp311-cp311-win32.whl", hash = "sha256:4afd5814270fdf6380616b321fd31435a462019d834f83c8611a0ce7484c7317", size = 36419 },
+    { url = "https://files.pythonhosted.org/packages/47/f8/fb1773491a253cbc123c5d5dc15c86041f746ed30416535f2a8df1f4a392/wrapt-1.17.2-cp311-cp311-win_amd64.whl", hash = "sha256:acc130bc0375999da18e3d19e5a86403667ac0c4042a094fefb7eec8ebac7cf3", size = 38773 },
+    { url = "https://files.pythonhosted.org/packages/a1/bd/ab55f849fd1f9a58ed7ea47f5559ff09741b25f00c191231f9f059c83949/wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925", size = 53799 },
+    { url = "https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392", size = 38821 },
+    { url = "https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40", size = 38919 },
+    { url = "https://files.pythonhosted.org/packages/73/54/3bfe5a1febbbccb7a2f77de47b989c0b85ed3a6a41614b104204a788c20e/wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d", size = 88721 },
+    { url = "https://files.pythonhosted.org/packages/25/cb/7262bc1b0300b4b64af50c2720ef958c2c1917525238d661c3e9a2b71b7b/wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b", size = 80899 },
+    { url = "https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98", size = 89222 },
+    { url = "https://files.pythonhosted.org/packages/09/28/2e45a4f4771fcfb109e244d5dbe54259e970362a311b67a965555ba65026/wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82", size = 86707 },
+    { url = "https://files.pythonhosted.org/packages/c6/d2/dcb56bf5f32fcd4bd9aacc77b50a539abdd5b6536872413fd3f428b21bed/wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae", size = 79685 },
+    { url = "https://files.pythonhosted.org/packages/80/4e/eb8b353e36711347893f502ce91c770b0b0929f8f0bed2670a6856e667a9/wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9", size = 87567 },
+    { url = "https://files.pythonhosted.org/packages/17/27/4fe749a54e7fae6e7146f1c7d914d28ef599dacd4416566c055564080fe2/wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9", size = 36672 },
+    { url = "https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991", size = 38865 },
+    { url = "https://files.pythonhosted.org/packages/ce/b9/0ffd557a92f3b11d4c5d5e0c5e4ad057bd9eb8586615cdaf901409920b14/wrapt-1.17.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6ed6ffac43aecfe6d86ec5b74b06a5be33d5bb9243d055141e8cabb12aa08125", size = 53800 },
+    { url = "https://files.pythonhosted.org/packages/c0/ef/8be90a0b7e73c32e550c73cfb2fa09db62234227ece47b0e80a05073b375/wrapt-1.17.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35621ae4c00e056adb0009f8e86e28eb4a41a4bfa8f9bfa9fca7d343fe94f998", size = 38824 },
+    { url = "https://files.pythonhosted.org/packages/36/89/0aae34c10fe524cce30fe5fc433210376bce94cf74d05b0d68344c8ba46e/wrapt-1.17.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a604bf7a053f8362d27eb9fefd2097f82600b856d5abe996d623babd067b1ab5", size = 38920 },
+    { url = "https://files.pythonhosted.org/packages/3b/24/11c4510de906d77e0cfb5197f1b1445d4fec42c9a39ea853d482698ac681/wrapt-1.17.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cbabee4f083b6b4cd282f5b817a867cf0b1028c54d445b7ec7cfe6505057cf8", size = 88690 },
+    { url = "https://files.pythonhosted.org/packages/71/d7/cfcf842291267bf455b3e266c0c29dcb675b5540ee8b50ba1699abf3af45/wrapt-1.17.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49703ce2ddc220df165bd2962f8e03b84c89fee2d65e1c24a7defff6f988f4d6", size = 80861 },
+    { url = "https://files.pythonhosted.org/packages/d5/66/5d973e9f3e7370fd686fb47a9af3319418ed925c27d72ce16b791231576d/wrapt-1.17.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8112e52c5822fc4253f3901b676c55ddf288614dc7011634e2719718eaa187dc", size = 89174 },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/8e17bb70f6ae25dabc1aaf990f86824e4fd98ee9cadf197054e068500d27/wrapt-1.17.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fee687dce376205d9a494e9c121e27183b2a3df18037f89d69bd7b35bcf59e2", size = 86721 },
+    { url = "https://files.pythonhosted.org/packages/6f/54/f170dfb278fe1c30d0ff864513cff526d624ab8de3254b20abb9cffedc24/wrapt-1.17.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:18983c537e04d11cf027fbb60a1e8dfd5190e2b60cc27bc0808e653e7b218d1b", size = 79763 },
+    { url = "https://files.pythonhosted.org/packages/4a/98/de07243751f1c4a9b15c76019250210dd3486ce098c3d80d5f729cba029c/wrapt-1.17.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:703919b1633412ab54bcf920ab388735832fdcb9f9a00ae49387f0fe67dad504", size = 87585 },
+    { url = "https://files.pythonhosted.org/packages/f9/f0/13925f4bd6548013038cdeb11ee2cbd4e37c30f8bfd5db9e5a2a370d6e20/wrapt-1.17.2-cp313-cp313-win32.whl", hash = "sha256:abbb9e76177c35d4e8568e58650aa6926040d6a9f6f03435b7a522bf1c487f9a", size = 36676 },
+    { url = "https://files.pythonhosted.org/packages/bf/ae/743f16ef8c2e3628df3ddfd652b7d4c555d12c84b53f3d8218498f4ade9b/wrapt-1.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:69606d7bb691b50a4240ce6b22ebb319c1cfb164e5f6569835058196e0f3a845", size = 38871 },
+    { url = "https://files.pythonhosted.org/packages/3d/bc/30f903f891a82d402ffb5fda27ec1d621cc97cb74c16fea0b6141f1d4e87/wrapt-1.17.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4a721d3c943dae44f8e243b380cb645a709ba5bd35d3ad27bc2ed947e9c68192", size = 56312 },
+    { url = "https://files.pythonhosted.org/packages/8a/04/c97273eb491b5f1c918857cd26f314b74fc9b29224521f5b83f872253725/wrapt-1.17.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:766d8bbefcb9e00c3ac3b000d9acc51f1b399513f44d77dfe0eb026ad7c9a19b", size = 40062 },
+    { url = "https://files.pythonhosted.org/packages/4e/ca/3b7afa1eae3a9e7fefe499db9b96813f41828b9fdb016ee836c4c379dadb/wrapt-1.17.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e496a8ce2c256da1eb98bd15803a79bee00fc351f5dfb9ea82594a3f058309e0", size = 40155 },
+    { url = "https://files.pythonhosted.org/packages/89/be/7c1baed43290775cb9030c774bc53c860db140397047cc49aedaf0a15477/wrapt-1.17.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d615e4fe22f4ad3528448c193b218e077656ca9ccb22ce2cb20db730f8d306", size = 113471 },
+    { url = "https://files.pythonhosted.org/packages/32/98/4ed894cf012b6d6aae5f5cc974006bdeb92f0241775addad3f8cd6ab71c8/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5aaeff38654462bc4b09023918b7f21790efb807f54c000a39d41d69cf552cb", size = 101208 },
+    { url = "https://files.pythonhosted.org/packages/ea/fd/0c30f2301ca94e655e5e057012e83284ce8c545df7661a78d8bfca2fac7a/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a7d15bbd2bc99e92e39f49a04653062ee6085c0e18b3b7512a4f2fe91f2d681", size = 109339 },
+    { url = "https://files.pythonhosted.org/packages/75/56/05d000de894c4cfcb84bcd6b1df6214297b8089a7bd324c21a4765e49b14/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3890b508a23299083e065f435a492b5435eba6e304a7114d2f919d400888cc6", size = 110232 },
+    { url = "https://files.pythonhosted.org/packages/53/f8/c3f6b2cf9b9277fb0813418e1503e68414cd036b3b099c823379c9575e6d/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8c8b293cd65ad716d13d8dd3624e42e5a19cc2a2f1acc74b30c2c13f15cb61a6", size = 100476 },
+    { url = "https://files.pythonhosted.org/packages/a7/b1/0bb11e29aa5139d90b770ebbfa167267b1fc548d2302c30c8f7572851738/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c82b8785d98cdd9fed4cac84d765d234ed3251bd6afe34cb7ac523cb93e8b4f", size = 106377 },
+    { url = "https://files.pythonhosted.org/packages/6a/e1/0122853035b40b3f333bbb25f1939fc1045e21dd518f7f0922b60c156f7c/wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555", size = 37986 },
+    { url = "https://files.pythonhosted.org/packages/09/5e/1655cf481e079c1f22d0cabdd4e51733679932718dc23bf2db175f329b76/wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c", size = 40750 },
+    { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594 },
+]
+
+[[package]]
 name = "xmltodict"
 version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/50/05/51dcca9a9bf5e1bce52582683ce50980bcadbc4fa5143b9f2b19ab99958f/xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553", size = 51942 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac", size = 9981 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630 },
 ]


### PR DESCRIPTION
# Context

We're improving the monitoring/alerting/debugging setup, and specifically integrating with Datadog that the department is moving towards.

In order to maintain reusability, Matchbox should continue to work without Datadog: it is an optional integration, both locally and when deployed.

## Changes proposed in this pull request

This change:

1. Runs the Datadog agent when running locally via docker compose using the "monitoring" profile

2. Sends traces to it from the api application by wrapping its startup with ddtrace-run as the ENTRYPOINT specified in the Dockerfile. It runs the agent and ddtrace-run in all cases in order to keep the local environment as similar as possible to deployed, but to actually sent data to Datadog, a real DD_API_KEY must be set in .datadog-agent-private.env. and the "monitoring" profile used with docker compose

It runs the agent and ddtrace-run in all cases in order to keep the local environment as similar as possible to deployed, but to actually sent data to Datadog, a real DD_API_KEY must be set in .datadog-agent-private.env.

Although the Datadog agent would typically not be crucial for local dev work, the plan is to run the agent when deployed, so this is a stepping stone to that.

## Guidance to review

1. Run matchbox locally with a real Datadog API key
2. Access to the Datadog browser interface
3. Check that traces appear in Datadog

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation