### PR TITLE
Move source retrieval out of selectors

### DIFF
--- a/src/matchbox/client/_handler.py
+++ b/src/matchbox/client/_handler.py
@@ -216,8 +216,7 @@ def index(source: Source, batch_size: int | None = None) -> UploadStatus:
 
 
 def get_source(address: SourceAddress) -> Source:
-    warehouse_hash_b64 = hash_to_base64(address.warehouse_hash)
-    res = CLIENT.get(f"/sources/{warehouse_hash_b64}/{address.full_name}")
+    res = CLIENT.get(f"/sources/{address.warehouse_hash_b64}/{address.full_name}")
 
     return Source.model_validate(res.json())
 

--- a/src/matchbox/client/dags.py
+++ b/src/matchbox/client/dags.py
@@ -99,6 +99,7 @@ class ModelStep(BaseModel, ABC):
             return_type="pandas",
             threshold=step_input.threshold,
             resolution_name=step_input.name,
+            only_indexed=True,
         )
 
         return df_raw

--- a/src/matchbox/client/dags.py
+++ b/src/matchbox/client/dags.py
@@ -90,7 +90,10 @@ class ModelStep(BaseModel, ABC):
         Returns:
             Pandas dataframe with retrieved results.
         """
-        selectors = [Selector(source=s, fields=f) for s, f in step_input.select.items()]
+        selectors = [
+            Selector(engine=s.engine, address=s.address, fields=f)
+            for s, f in step_input.select.items()
+        ]
         df_raw = query(
             selectors,
             return_type="pandas",

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -148,22 +148,18 @@ def _source_query(
                 f"{selected_fields - warehouse_cols} not in {selector.address}"
             )
 
-        fields = None
-        if selector.fields:
-            fields = list(set(selector.fields))
+    iter_batches = False
+    if batch_size:
+        iter_batches = True
 
-        iter_batches = False
-        if batch_size:
-            iter_batches = True
+    raw_results = source.to_arrow(
+        fields=list(selected_fields) if selected_fields else None,
+        pks=mb_ids["source_pk"].to_pylist(),
+        iter_batches=iter_batches,
+        batch_size=batch_size,
+    )
 
-        raw_results = source.to_arrow(
-            fields=fields,
-            pks=mb_ids["source_pk"].to_pylist(),
-            iter_batches=iter_batches,
-            batch_size=batch_size,
-        )
-
-        return source, raw_results
+    return source, raw_results
 
 
 def _query_batched(

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -2,7 +2,6 @@
 
 import itertools
 from typing import Iterator, Literal, get_args
-from warnings import warn
 
 import polars as pl
 import pyarrow as pa
@@ -30,7 +29,6 @@ class Selector(BaseModel):
 def select(
     *selection: str | dict[str, str],
     engine: Engine | None = None,
-    only_indexed: bool = True,
 ) -> list[Selector]:
     """From one engine, builds and verifies a list of selectors.
 
@@ -39,10 +37,6 @@ def select(
         engine: The engine to connect to the data warehouse hosting the source.
             If not provided, will use a connection string from the
             `MB__CLIENT__DEFAULT_WAREHOUSE` environment variable.
-        only_indexed: Whether you intend to select indexed columns only. Will raise a
-            warning if True and non-indexed columns are selected. Defaults to True.
-            Non-indexed columns should only be selected if you're querying data for
-            a purpose other than matching
 
     Returns:
         A list of Selector objects
@@ -84,12 +78,6 @@ def select(
                         f"{selected_cols - warehouse_cols} not in {source_address}"
                     )
 
-                indexed_cols = set(col.name for col in source.columns)
-                if (not selected_cols <= indexed_cols) and only_indexed:
-                    warn(
-                        "You are selecting columns that are not indexed in Matchbox",
-                        stacklevel=2,
-                    )
                 selectors.append(Selector(source=source, fields=fields))
         else:
             raise ValueError("Selection specified in incorrect format")

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -139,21 +139,16 @@ def _source_query(
     """From a Selector, query a source and join to matchbox IDs."""
     source = _handler.get_source(selector.address).set_engine(selector.engine)
 
-    warehouse_cols = set(source.to_table().columns.keys())
     selected_fields = None
     if selector.fields:
-        selected_fields = set(selector.fields)
-        if not selected_fields <= warehouse_cols:
-            raise ValueError(
-                f"{selected_fields - warehouse_cols} not in {selector.address}"
-            )
+        selected_fields = list(set(selector.fields))
 
     iter_batches = False
     if batch_size:
         iter_batches = True
 
     raw_results = source.to_arrow(
-        fields=list(selected_fields) if selected_fields else None,
+        fields=selected_fields,
         pks=mb_ids["source_pk"].to_pylist(),
         iter_batches=iter_batches,
         batch_size=batch_size,

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -114,23 +114,6 @@ def _process_query_result(
         return joined_table
 
 
-def _get_matchbox_ids(
-    source_address: SourceAddress,
-    resolution_name: str,
-    threshold: int | None = None,
-    limit: int | None = None,
-) -> ArrowTable:
-    """Get matchbox IDs for a source and resolution."""
-    mb_ids = _handler.query(
-        source_address=source_address,
-        resolution_name=resolution_name,
-        threshold=threshold,
-        limit=limit,
-    )
-
-    return mb_ids
-
-
 def _source_query(
     selector: Selector,
     mb_ids: ArrowTable,
@@ -179,7 +162,7 @@ def _query_batched(
     selector_iters = []
 
     for selector, sub_limit in zip(selectors, sub_limits, strict=True):
-        mb_ids = _get_matchbox_ids(
+        mb_ids = _handler.query(
             source_address=selector.address,
             resolution_name=resolution_name,
             threshold=threshold,
@@ -346,7 +329,7 @@ def query(
         tables = []
         for selector, sub_limit in zip(selectors, sub_limits, strict=True):
             # Get ids from matchbox
-            mb_ids = _get_matchbox_ids(
+            mb_ids = _handler.query(
                 source_address=selector.address,
                 resolution_name=resolution_name,
                 threshold=threshold,

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -140,11 +140,11 @@ def _source_query(
     """From a Selector, query a source and join to matchbox IDs."""
     source = _handler.get_source(selector.address).set_engine(selector.engine)
 
+    indexed_columns = set()
     if source.columns:
         indexed_columns = set([col.name for col in source.columns])
-    else:
-        # If only_indexed is True and source.columns is unset, we will raise
-        indexed_columns = set()
+
+    # If only_indexed is True and source.columns is unset, we will raise
     if only_indexed and selector.fields and not set(selector.fields) <= indexed_columns:
         raise ValueError("Attempting to query unindexed columns.")
 
@@ -152,14 +152,10 @@ def _source_query(
     if selector.fields:
         selected_fields = list(set(selector.fields))
 
-    iter_batches = False
-    if batch_size:
-        iter_batches = True
-
     raw_results = source.to_arrow(
         fields=selected_fields,
         pks=mb_ids["source_pk"].to_pylist(),
-        iter_batches=iter_batches,
+        iter_batches=bool(batch_size),
         batch_size=batch_size,
     )
 

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -140,7 +140,11 @@ def _source_query(
     """From a Selector, query a source and join to matchbox IDs."""
     source = _handler.get_source(selector.address).set_engine(selector.engine)
 
-    indexed_columns = set([col.name for col in source.columns])
+    if source.columns:
+        indexed_columns = set([col.name for col in source.columns])
+    else:
+        # If only_indexed is True and source.columns is unset, we will raise
+        indexed_columns = set()
     if only_indexed and selector.fields and not set(selector.fields) <= indexed_columns:
         raise ValueError("Attempting to query unindexed columns.")
 

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -97,14 +97,16 @@ def _process_query_result(
     # Join data with matchbox IDs
     joined_table = data.join(
         right_table=mb_ids,
-        keys=selector.source.format_column(selector.source.db_pk),
+        keys=selector.address.format_column(selector.source.db_pk),
         right_keys="source_pk",
         join_type="inner",
     )
 
     # Apply field filtering if needed
     if selector.fields:
-        keep_cols = ["id"] + [selector.source.format_column(f) for f in selector.fields]
+        keep_cols = ["id"] + [
+            selector.address.format_column(f) for f in selector.fields
+        ]
         match_cols = [col for col in joined_table.column_names if col in keep_cols]
         return joined_table.select(match_cols)
     else:

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -419,10 +419,10 @@ def match(
     """
     if len(source) > 1:
         raise ValueError("Only one source can be matched at one time")
-    source = source[0].source.address
+    source = source[0].address
 
-    targets = list(itertools.chain(*targets))
-    targets = [t.source.address for t in targets]
+    targets: list[Selector] = list(itertools.chain(*targets))
+    targets = [t.address for t in targets]
 
     return _handler.match(
         targets=targets,

--- a/src/matchbox/common/exceptions.py
+++ b/src/matchbox/common/exceptions.py
@@ -44,7 +44,7 @@ class MatchboxUnhandledServerResponse(Exception):
 
 
 class MatchboxSourceColumnError(Exception):
-    """Source columns diverge with the warehouse."""
+    """Specified columns diverge with the warehouse."""
 
 
 class MatchboxSourceEngineError(Exception):

--- a/src/matchbox/common/factories/entities.py
+++ b/src/matchbox/common/factories/entities.py
@@ -112,7 +112,7 @@ def infer_sql_type(base: str, parameters: tuple) -> str:
         if all(issubclass(t, (int, float, Decimal)) for t in types_found):
             if any(issubclass(t, float) or issubclass(t, Decimal) for t in types_found):
                 return "FLOAT"
-            return "INTEGER"
+            return "BIGINT"
         # Default to TEXT for mixed types
         return "TEXT"
 
@@ -121,7 +121,7 @@ def infer_sql_type(base: str, parameters: tuple) -> str:
 
     type_map = {
         str: "TEXT",
-        int: "INTEGER",
+        int: "BIGINT",
         float: "FLOAT",
         bool: "BOOLEAN",
         datetime.datetime: "TIMESTAMP",

--- a/src/matchbox/common/factories/entities.py
+++ b/src/matchbox/common/factories/entities.py
@@ -539,17 +539,6 @@ def generate_entities(
     return tuple(entities)
 
 
-def generate_entities_from_tuple(
-    data_tuple: tuple[dict[str, Any], ...],
-) -> tuple[SourceEntity]:
-    """Generate base entities from tuple of rows."""
-    entities = []
-    for row in data_tuple:
-        entities.append(SourceEntity(base_values=row, source_pks=EntityReference()))
-
-    return tuple(entities)
-
-
 def probabilities_to_results_entities(
     probabilities: pa.Table,
     left_clusters: tuple[ClusterEntity, ...],

--- a/src/matchbox/common/factories/sources.py
+++ b/src/matchbox/common/factories/sources.py
@@ -23,7 +23,6 @@ from matchbox.common.factories.entities import (
     SuffixRule,
     diff_results,
     generate_entities,
-    generate_entities_from_tuple,
     infer_sql_type_from_type,
     probabilities_to_results_entities,
 )
@@ -486,7 +485,7 @@ def source_from_tuple(
     if engine is None:
         engine = create_engine("sqlite:///:memory:")
 
-    base_entities = generate_entities_from_tuple(data_tuple=data_tuple)
+    base_entities = tuple(SourceEntity(base_values=row) for row in data_tuple)
 
     # Create source entities with references
     source_entities: list[SourceEntity] = []

--- a/src/matchbox/common/factories/sources.py
+++ b/src/matchbox/common/factories/sources.py
@@ -3,7 +3,7 @@
 import warnings
 from functools import cache, wraps
 from itertools import product
-from typing import Callable, ParamSpec, TypeVar
+from typing import Any, Callable, ParamSpec, TypeVar
 from unittest.mock import Mock, create_autospec
 from uuid import uuid4
 
@@ -23,8 +23,11 @@ from matchbox.common.factories.entities import (
     SuffixRule,
     diff_results,
     generate_entities,
+    generate_entities_from_tuple,
+    infer_sql_type_from_type,
     probabilities_to_results_entities,
 )
+from matchbox.common.hash import hash_values
 from matchbox.common.sources import Source, SourceAddress, SourceColumn
 
 P = ParamSpec("P")
@@ -79,8 +82,9 @@ class SourceTestkit(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     source: Source = Field(description="The real generated Source object.")
-    features: tuple[FeatureConfig, ...] = Field(
-        description="The features used to generate the data."
+    features: tuple[FeatureConfig, ...] | None = Field(
+        description="The features used to generate the data.",
+        default=None,
     )
     data: pa.Table = Field(description="The PyArrow table of generated data.")
     data_hashes: pa.Table = Field(description="A PyArrow table of hashes for the data.")
@@ -391,7 +395,7 @@ def source_factory(
     repetition: int = 0,
     seed: int = 42,
 ) -> SourceTestkit:
-    """Generate a complete source testkit."""
+    """Generate a complete source testkit from configured features."""
     generator = Faker()
     generator.seed_instance(seed)
 
@@ -459,6 +463,71 @@ def source_factory(
     return SourceTestkit(
         source=source,
         features=features,
+        data=data,
+        data_hashes=data_hashes,
+        entities=tuple(sorted(results_entities)),
+    )
+
+
+def source_from_tuple(
+    data_tuple: tuple[dict[str, Any], ...],
+    data_pks: tuple[str],
+    full_name: str | None = None,
+    engine: Engine | None = None,
+    seed: int = 42,
+) -> SourceTestkit:
+    """Generate a complete source testkit from dummy data."""
+    generator = Faker()
+    generator.seed_instance(seed)
+
+    if full_name is None:
+        full_name = generator.unique.word()
+
+    if engine is None:
+        engine = create_engine("sqlite:///:memory:")
+
+    base_entities = generate_entities_from_tuple(data_tuple=data_tuple)
+
+    # Create source entities with references
+    source_entities: list[SourceEntity] = []
+    for entity, pk in zip(base_entities, data_pks, strict=True):
+        entity.add_source_reference(full_name, [pk])
+        source_entities.append(entity)
+    entity_ids = {entity.id for entity in source_entities}
+
+    # Create ClusterEntity objects from row_pks
+    results_entities = [
+        ClusterEntity(
+            id=entity_id,
+            source_pks=EntityReference({full_name: frozenset([pk])}),
+        )
+        for pk, entity_id in zip(data_pks, entity_ids, strict=True)
+    ]
+
+    source = Source(
+        address=SourceAddress.compose(full_name=full_name, engine=engine),
+        db_pk="pk",
+        columns=(
+            SourceColumn(name=k, type=infer_sql_type_from_type(type(v)))
+            for k, v in data_tuple[0].items()
+        ),
+    )
+
+    hashes = [hash_values(*row) for row in data_tuple]
+
+    data_hashes = pa.Table.from_pydict(
+        {
+            "source_pk": data_pks,
+            "hash": hashes,
+        },
+        schema=SCHEMA_INDEX,
+    )
+
+    raw_data = pa.Table.from_pylist(list(data_tuple))
+    data = raw_data.append_column("id", [entity_ids]).append_column("pk", data_pks)
+
+    return SourceTestkit(
+        source=source,
         data=data,
         data_hashes=data_hashes,
         entities=tuple(sorted(results_entities)),

--- a/src/matchbox/common/factories/sources.py
+++ b/src/matchbox/common/factories/sources.py
@@ -82,7 +82,10 @@ class SourceTestkit(BaseModel):
 
     source: Source = Field(description="The real generated Source object.")
     features: tuple[FeatureConfig, ...] | None = Field(
-        description="The features used to generate the data.",
+        description=(
+            "The features used to generate the data. "
+            "If None, the source data was not generated, but set manually."
+        ),
         default=None,
     )
     data: pa.Table = Field(description="The PyArrow table of generated data.")

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -82,7 +82,12 @@ class SourceAddress(BaseModel):
 
     def __str__(self) -> str:
         """Convert to a string."""
-        return self.full_name + "@" + hash_to_base64(self.warehouse_hash)
+        return self.full_name + "@" + self.warehouse_hash_b64
+
+    @property
+    def warehouse_hash_b64(self) -> str:
+        """Return warehouse hash as a base64 encoded string."""
+        return hash_to_base64(self.warehouse_hash)
 
     @classmethod
     def compose(cls, engine: Engine, full_name: str) -> "SourceAddress":

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -241,6 +241,9 @@ class Source(BaseModel):
     @needs_engine
     def check_columns(self) -> None:
         """Check that set columns are available in the warehouse and correctly typed."""
+        if not self.columns:
+            raise ValueError("Columns must be set before checking.")
+
         remote_columns = self._get_remote_columns()
         for col in self.columns:
             if col.name not in remote_columns:

--- a/test/client/test_dags.py
+++ b/test/client/test_dags.py
@@ -116,6 +116,7 @@ def test_dedupe_step_run(
             return_type="pandas",
             threshold=d_foo.left.threshold,
             resolution_name=d_foo.left.name,
+            only_indexed=True,
         )
         # Data is pre-processed
         process_mock.assert_called_once_with(
@@ -182,12 +183,14 @@ def test_link_step_run(
             return_type="pandas",
             threshold=foo_bar.left.threshold,
             resolution_name=foo_bar.left.name,
+            only_indexed=True,
         )
         assert query_mock.call_args_list[1] == call(
             [Selector(engine=sqlite_warehouse, address=bar.address, fields=[])],
             return_type="pandas",
             threshold=foo_bar.right.threshold,
             resolution_name=foo_bar.right.name,
+            only_indexed=True,
         )
 
         # Data is pre-processed

--- a/test/client/test_dags.py
+++ b/test/client/test_dags.py
@@ -96,7 +96,9 @@ def test_dedupe_step_run(
         model_mock.run = Mock(return_value=results_mock)
 
         # Set up and run deduper
-        foo = source_factory(full_name="foo", engine=sqlite_warehouse).source
+        foo = source_factory(
+            full_name="foo", engine=sqlite_warehouse
+        ).source.set_engine(sqlite_warehouse)
         d_foo = DedupeStep(
             name="d_foo",
             description="",
@@ -110,7 +112,7 @@ def test_dedupe_step_run(
 
         # Right data is queried
         query_mock.assert_called_once_with(
-            [Selector(source=foo, fields=[])],
+            [Selector(engine=sqlite_warehouse, address=foo.address, fields=[])],
             return_type="pandas",
             threshold=d_foo.left.threshold,
             resolution_name=d_foo.left.name,
@@ -155,8 +157,12 @@ def test_link_step_run(
         model_mock.run = Mock(return_value=results_mock)
 
         # Set up and run deduper
-        foo = source_factory(full_name="foo", engine=sqlite_warehouse).source
-        bar = source_factory(full_name="bar", engine=sqlite_warehouse).source
+        foo = source_factory(
+            full_name="foo", engine=sqlite_warehouse
+        ).source.set_engine(sqlite_warehouse)
+        bar = source_factory(
+            full_name="bar", engine=sqlite_warehouse
+        ).source.set_engine(sqlite_warehouse)
         foo_bar = LinkStep(
             name="foo_bar",
             description="",
@@ -172,13 +178,13 @@ def test_link_step_run(
         # Right data is queried
         assert query_mock.call_count == 2
         assert query_mock.call_args_list[0] == call(
-            [Selector(source=foo, fields=[])],
+            [Selector(engine=sqlite_warehouse, address=foo.address, fields=[])],
             return_type="pandas",
             threshold=foo_bar.left.threshold,
             resolution_name=foo_bar.left.name,
         )
         assert query_mock.call_args_list[1] == call(
-            [Selector(source=bar, fields=[])],
+            [Selector(engine=sqlite_warehouse, address=bar.address, fields=[])],
             return_type="pandas",
             threshold=foo_bar.right.threshold,
             resolution_name=foo_bar.right.name,

--- a/test/client/test_helpers.py
+++ b/test/client/test_helpers.py
@@ -145,24 +145,6 @@ def test_select_mixed_style(matchbox_api: MockRouter, sqlite_warehouse: Engine):
     assert selection[1].engine == sqlite_warehouse
 
 
-# def test_select_non_indexed_columns(matchbox_api: MockRouter,
-# sqlite_warehouse: Engine):
-#     """Selecting columns not declared to backend generates warning."""
-#     source_testkit = source_factory(full_name="foo", engine=sqlite_warehouse)
-
-#     source = source_testkit.source
-#     source = source.model_copy(update={"columns": source.columns[:1]})
-
-#     matchbox_api.get(
-#         f"/sources/{hash_to_base64(source.address.warehouse_hash)}/foo"
-#     ).mock(return_value=Response(200, content=source.model_dump_json()))
-
-#     source_testkit.to_warehouse(engine=sqlite_warehouse)
-
-#     with pytest.warns(Warning):
-#         select({"foo": ["company_name", "crn"]}, engine=sqlite_warehouse)
-
-
 def test_query_no_resolution_ok_various_params(
     matchbox_api: MockRouter, sqlite_warehouse: Engine
 ):

--- a/test/client/test_helpers.py
+++ b/test/client/test_helpers.py
@@ -312,11 +312,7 @@ def test_query_combine_type(
     """Various ways of combining multiple sources are supported."""
     # Dummy data and source
     testkit1 = source_from_tuple(
-        data_tuple=(
-            {"col": 20},
-            {"col": 40},
-            {"col": 60},
-        ),
+        data_tuple=({"col": 20}, {"col": 40}, {"col": 60}),
         data_pks=["0", "1", "2"],
         full_name="foo",
         engine=sqlite_warehouse,

--- a/test/client/test_helpers.py
+++ b/test/client/test_helpers.py
@@ -291,7 +291,6 @@ def test_query_multiple_sources_with_limits(
         * 2  # 2 calls to `query()` in this test, each querying server twice
     )
 
-    # Well-formed select from these mocks
     sels = select("foo", {"foo2": ["c"]}, engine=sqlite_warehouse)
 
     # Validate results
@@ -401,7 +400,6 @@ def test_query_combine_type(
         ]  # two sources to query
     )
 
-    # Well-formed select from these mocks
     sels = select("foo", "bar", engine=sqlite_warehouse)
 
     # Validate results
@@ -477,7 +475,6 @@ def test_query_404_resolution(matchbox_api: MockRouter, sqlite_warehouse: Engine
         )
     )
 
-    # Well-formed selector for these mocks
     selectors = select({"foo": ["a", "b"]}, engine=sqlite_warehouse)
 
     # Test with no optional params
@@ -497,7 +494,6 @@ def test_query_404_source(matchbox_api: MockRouter, sqlite_warehouse: Engine):
         )
     )
 
-    # Well-formed selector for these mocks
     sels = select({"foo": ["a", "b"]}, engine=sqlite_warehouse)
 
     # Test with no optional params
@@ -564,7 +560,6 @@ def test_query_with_batches(
         )
     )
 
-    # Well-formed selector for these mocks
     sels = select("foo", engine=sqlite_warehouse)
 
     # Test with return_batches=True

--- a/test/client/test_helpers.py
+++ b/test/client/test_helpers.py
@@ -163,24 +163,6 @@ def test_select_mixed_style(matchbox_api: MockRouter, sqlite_warehouse: Engine):
 #         select({"foo": ["company_name", "crn"]}, engine=sqlite_warehouse)
 
 
-# def test_select_missing_columns(matchbox_api: MockRouter, sqlite_warehouse: Engine):
-#     """Selecting columns not in the warehouse errors."""
-#     source_testkit = source_factory(full_name="foo", engine=sqlite_warehouse)
-
-#     source = source_testkit.source
-
-#     matchbox_api.get(
-#         f"/sources/{hash_to_base64(source.address.warehouse_hash)}/foo"
-#     ).mock(return_value=Response(200, content=source.model_dump_json()))
-
-#     source_testkit.to_warehouse(engine=sqlite_warehouse)
-
-#     with pytest.raises(ValueError):
-#         select(
-#             {"foo": ["company_name", "non_existent_column"]}, engine=sqlite_warehouse
-#         )
-
-
 def test_query_no_resolution_ok_various_params(
     matchbox_api: MockRouter, sqlite_warehouse: Engine
 ):

--- a/test/client/test_helpers.py
+++ b/test/client/test_helpers.py
@@ -15,7 +15,7 @@ from matchbox.client._handler import create_client
 from matchbox.client._settings import ClientSettings
 from matchbox.client.clean import company_name, company_number
 from matchbox.client.helpers import cleaner, cleaners, comparison, select
-from matchbox.client.helpers.selector import Match, Selector
+from matchbox.client.helpers.selector import Match
 from matchbox.common.arrow import SCHEMA_MB_IDS, table_to_buffer
 from matchbox.common.db import get_schema_table_names
 from matchbox.common.dtos import (
@@ -465,7 +465,7 @@ def test_query_unindexed_fields(matchbox_api: MockRouter, sqlite_warehouse: Engi
         query(selectors, only_indexed=True)
 
 
-def test_query_404_resolution(matchbox_api: MockRouter):
+def test_query_404_resolution(matchbox_api: MockRouter, sqlite_warehouse: Engine):
     # Mock API
     matchbox_api.get("/query").mock(
         return_value=Response(
@@ -478,25 +478,14 @@ def test_query_404_resolution(matchbox_api: MockRouter):
     )
 
     # Well-formed selector for these mocks
-    sels = [
-        Selector(
-            source=Source(
-                address=SourceAddress(
-                    full_name="foo",
-                    warehouse_hash=b"bar",
-                ),
-                db_pk="pk",
-            ),
-            fields=["a", "b"],
-        )
-    ]
+    selectors = select({"foo": ["a", "b"]}, engine=sqlite_warehouse)
 
     # Test with no optional params
     with pytest.raises(MatchboxResolutionNotFoundError, match="42"):
-        query(sels)
+        query(selectors)
 
 
-def test_query_404_source(matchbox_api: MockRouter):
+def test_query_404_source(matchbox_api: MockRouter, sqlite_warehouse: Engine):
     # Mock API
     matchbox_api.get("/query").mock(
         return_value=Response(
@@ -509,18 +498,7 @@ def test_query_404_source(matchbox_api: MockRouter):
     )
 
     # Well-formed selector for these mocks
-    sels = [
-        Selector(
-            source=Source(
-                address=SourceAddress(
-                    full_name="foo",
-                    warehouse_hash=b"bar",
-                ),
-                db_pk="pk",
-            ),
-            fields=["a", "b"],
-        )
-    ]
+    sels = select({"foo": ["a", "b"]}, engine=sqlite_warehouse)
 
     # Test with no optional params
     with pytest.raises(MatchboxSourceNotFoundError, match="42"):
@@ -911,7 +889,7 @@ def test_match_ok(matchbox_api: MockRouter, sqlite_warehouse: Engine):
     )
 
 
-def test_match_404_resolution(matchbox_api: MockRouter):
+def test_match_404_resolution(matchbox_api: MockRouter, sqlite_warehouse: Engine):
     """The client can handle a resolution not found error."""
     # Set up mocks
     matchbox_api.get("/match").mock(
@@ -925,30 +903,8 @@ def test_match_404_resolution(matchbox_api: MockRouter):
     )
 
     # Use match function
-    source = [
-        Selector(
-            source=Source(
-                address=SourceAddress(
-                    full_name="test.source",
-                    warehouse_hash=b"bar",
-                ),
-                db_pk="pk",
-            ),
-            fields=["a", "b"],
-        )
-    ]
-    target = [
-        Selector(
-            source=Source(
-                address=SourceAddress(
-                    full_name="test.target1",
-                    warehouse_hash=b"bar",
-                ),
-                db_pk="pk",
-            ),
-            fields=["a", "b"],
-        )
-    ]
+    source = select({"test.source": ["a", "b"]}, engine=sqlite_warehouse)
+    target = select({"test.target1": ["a", "b"]}, engine=sqlite_warehouse)
 
     with pytest.raises(MatchboxResolutionNotFoundError, match="42"):
         match(
@@ -959,7 +915,7 @@ def test_match_404_resolution(matchbox_api: MockRouter):
         )
 
 
-def test_match_404_source(matchbox_api: MockRouter):
+def test_match_404_source(matchbox_api: MockRouter, sqlite_warehouse: Engine):
     """The client can handle a source not found error."""
     # Set up mocks
     matchbox_api.get("/match").mock(
@@ -973,30 +929,8 @@ def test_match_404_source(matchbox_api: MockRouter):
     )
 
     # Use match function
-    source = [
-        Selector(
-            source=Source(
-                address=SourceAddress(
-                    full_name="test.source",
-                    warehouse_hash=b"bar",
-                ),
-                db_pk="pk",
-            ),
-            fields=["a", "b"],
-        )
-    ]
-    target = [
-        Selector(
-            source=Source(
-                address=SourceAddress(
-                    full_name="test.target1",
-                    warehouse_hash=b"bar",
-                ),
-                db_pk="pk",
-            ),
-            fields=["a", "b"],
-        )
-    ]
+    source = select({"test.source": ["a", "b"]}, engine=sqlite_warehouse)
+    target = select({"test.target1": ["a", "b"]}, engine=sqlite_warehouse)
 
     with pytest.raises(MatchboxSourceNotFoundError, match="42"):
         match(

--- a/test/common/factories/test_entity_factory.py
+++ b/test/common/factories/test_entity_factory.py
@@ -11,7 +11,6 @@ from matchbox.common.factories.entities import (
     SourceEntity,
     diff_results,
     generate_entities,
-    generate_entities_from_tuple,
     probabilities_to_results_entities,
 )
 
@@ -142,16 +141,6 @@ def test_generate_entities(features: tuple[FeatureConfig, ...], n: int):
         assert all(f.name in entity.base_values for f in features)
         # Check all values are strings (given our test features)
         assert all(isinstance(v, str) for v in entity.base_values.values())
-
-
-def test_generate_entities_from_tuples():
-    """Test entity generation with different features and counts."""
-    data_tuple = ({"a": 1, "b": "val"}, {"a": 2, "b": "val"})
-    entities: tuple[SourceEntity] = generate_entities_from_tuple(data_tuple)
-
-    assert len(entities) == 2
-    assert entities[0].base_values == data_tuple[0]
-    assert entities[1].base_values == data_tuple[1]
 
 
 @pytest.mark.parametrize(

--- a/test/common/factories/test_entity_factory.py
+++ b/test/common/factories/test_entity_factory.py
@@ -427,7 +427,7 @@ def test_source_to_results_conversion():
     ("base_generator", "expected_type"),
     [
         pytest.param("name", "TEXT", id="text_generator"),
-        pytest.param("random_int", "INTEGER", id="integer_generator"),
+        pytest.param("random_int", "BIGINT", id="integer_generator"),
         pytest.param("date_this_decade", "DATE", id="date_generator"),
     ],
 )

--- a/test/common/factories/test_entity_factory.py
+++ b/test/common/factories/test_entity_factory.py
@@ -11,6 +11,7 @@ from matchbox.common.factories.entities import (
     SourceEntity,
     diff_results,
     generate_entities,
+    generate_entities_from_tuple,
     probabilities_to_results_entities,
 )
 
@@ -141,6 +142,16 @@ def test_generate_entities(features: tuple[FeatureConfig, ...], n: int):
         assert all(f.name in entity.base_values for f in features)
         # Check all values are strings (given our test features)
         assert all(isinstance(v, str) for v in entity.base_values.values())
+
+
+def test_generate_entities_from_tuples():
+    """Test entity generation with different features and counts."""
+    data_tuple = ({"a": 1, "b": "val"}, {"a": 2, "b": "val"})
+    entities: tuple[SourceEntity] = generate_entities_from_tuple(data_tuple)
+
+    assert len(entities) == 2
+    assert entities[0].base_values == data_tuple[0]
+    assert entities[0].base_values == data_tuple[1]
 
 
 @pytest.mark.parametrize(

--- a/test/common/factories/test_entity_factory.py
+++ b/test/common/factories/test_entity_factory.py
@@ -151,7 +151,7 @@ def test_generate_entities_from_tuples():
 
     assert len(entities) == 2
     assert entities[0].base_values == data_tuple[0]
-    assert entities[0].base_values == data_tuple[1]
+    assert entities[1].base_values == data_tuple[1]
 
 
 @pytest.mark.parametrize(

--- a/test/common/factories/test_source_factory.py
+++ b/test/common/factories/test_source_factory.py
@@ -14,6 +14,7 @@ from matchbox.common.factories.entities import (
 from matchbox.common.factories.sources import (
     generate_rows,
     source_factory,
+    source_from_tuple,
 )
 from matchbox.common.sources import SourceAddress
 
@@ -388,6 +389,26 @@ def test_source_factory_id_generation():
 
     # Different rows should have different IDs
     assert len(data_df["id"].unique()) == len(data_df["company_name"].unique())
+
+
+def test_source_from_tuple():
+    """Test that source_factory can create a source from a tuple of values."""
+    # Create a source from a tuple of values
+
+    testkit = source_from_tuple(
+        data_tuple=(
+            {"a": 1, "b": "val"},
+            {"a": 2, "b": "val"},
+        ),
+        data_pks=["0", "1"],
+    )
+
+    # Verify the generated source has the expected properties
+    assert len(testkit.entities) == 2
+    assert testkit.data.shape[0] == 2
+    assert set(testkit.data.column_names) == {"id", "pk", "a", "b"}
+    assert testkit.data_hashes.shape[0] == 2
+    assert set(col.name for col in testkit.source.columns) == {"a", "b"}
 
 
 @pytest.mark.parametrize(

--- a/test/common/factories/test_source_factory.py
+++ b/test/common/factories/test_source_factory.py
@@ -394,14 +394,16 @@ def test_source_factory_id_generation():
 def test_source_from_tuple():
     """Test that source_factory can create a source from a tuple of values."""
     # Create a source from a tuple of values
-
+    data_tuple = ({"a": 1, "b": "val"}, {"a": 2, "b": "val"})
     testkit = source_from_tuple(
-        data_tuple=({"a": 1, "b": "val"}, {"a": 2, "b": "val"}),
-        data_pks=["0", "1"],
+        data_tuple=data_tuple, data_pks=["0", "1"], full_name="foo"
     )
 
-    # Verify the generated source has the expected properties
+    # Verify the generated testkit has the expected properties
     assert len(testkit.entities) == 2
+    assert set(testkit.entities[0].source_pks["foo"]) == {"0"}
+    assert set(testkit.entities[1].source_pks["foo"]) == {"1"}
+
     assert testkit.data.shape[0] == 2
     assert set(testkit.data.column_names) == {"id", "pk", "a", "b"}
     assert testkit.data_hashes.shape[0] == 2

--- a/test/common/factories/test_source_factory.py
+++ b/test/common/factories/test_source_factory.py
@@ -401,8 +401,9 @@ def test_source_from_tuple():
 
     # Verify the generated testkit has the expected properties
     assert len(testkit.entities) == 2
-    assert set(testkit.entities[0].source_pks["foo"]) == {"0"}
-    assert set(testkit.entities[1].source_pks["foo"]) == {"1"}
+    assert set(testkit.entities[0].source_pks["foo"]) | set(
+        testkit.entities[1].source_pks["foo"]
+    ) == {"0", "1"}
 
     assert testkit.data.shape[0] == 2
     assert set(testkit.data.column_names) == {"id", "pk", "a", "b"}

--- a/test/common/factories/test_source_factory.py
+++ b/test/common/factories/test_source_factory.py
@@ -396,10 +396,7 @@ def test_source_from_tuple():
     # Create a source from a tuple of values
 
     testkit = source_from_tuple(
-        data_tuple=(
-            {"a": 1, "b": "val"},
-            {"a": 2, "b": "val"},
-        ),
+        data_tuple=({"a": 1, "b": "val"}, {"a": 2, "b": "val"}),
         data_pks=["0", "1"],
     )
 

--- a/test/common/test_sources.py
+++ b/test/common/test_sources.py
@@ -76,6 +76,15 @@ def test_source_address_compose():
     assert len(same_table_name_str) == 1
 
 
+def test_source_address_format_columns():
+    """Column names can get a standard prefix from a table name."""
+    address1 = SourceAddress(full_name="foo", warehouse_hash=b"bar")
+    address2 = SourceAddress(full_name="foo.bar", warehouse_hash=b"bar")
+
+    assert address1.format_column("col") == "foo_col"
+    assert address2.format_column("col") == "foo_bar_col"
+
+
 def test_source_set_engine(sqlite_warehouse: Engine):
     """Engine can be set on Source."""
     source_testkit = source_factory(
@@ -223,20 +232,6 @@ def test_source_hash_equality(sqlite_warehouse: Engine):
     assert source.engine != source_eq.engine
     assert source == source_eq
     assert hash(source) == hash(source_eq)
-
-
-def test_source_format_columns():
-    """Column names can get a standard prefix from a table name."""
-    source1 = Source(
-        address=SourceAddress(full_name="foo", warehouse_hash=b"bar"), db_pk="i"
-    )
-
-    source2 = Source(
-        address=SourceAddress(full_name="foo.bar", warehouse_hash=b"bar"), db_pk="i"
-    )
-
-    assert source1.format_column("col") == "foo_col"
-    assert source2.format_column("col") == "foo_bar_col"
 
 
 def test_source_default_columns(sqlite_warehouse: Engine):

--- a/test/common/test_sources.py
+++ b/test/common/test_sources.py
@@ -111,6 +111,10 @@ def test_source_check_columns(sqlite_warehouse: Engine):
     source = source_testkit.source.set_engine(sqlite_warehouse)
     assert isinstance(source, Source)
 
+    # Error is raised with custom columns
+    with pytest.raises(MatchboxSourceColumnError, match="Columns {'c'} not in"):
+        source.check_columns(columns=["c"])
+
     # Error is raised with missing column
     with pytest.raises(MatchboxSourceColumnError, match="Column c not available in"):
         new_source = source_testkit.source.model_copy(

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -397,14 +397,8 @@ class TestE2EAnalyticalUser:
         # Query data from the first linked pair and the third source
         # PK included then dropped to create ClusterEntity objects for later diff
         left_raw_df = query(
-            select(
-                {crn_source: ["pk", "crn"]},
-                engine=self.warehouse_engine,
-            ),
-            select(
-                {duns_source: ["pk"]},
-                engine=self.warehouse_engine,
-            ),
+            select({crn_source: ["pk", "crn"]}, engine=self.warehouse_engine),
+            select({duns_source: ["pk"]}, engine=self.warehouse_engine),
             resolution_name=linker_names[first_pair],
             return_type="pandas",
         )
@@ -415,16 +409,12 @@ class TestE2EAnalyticalUser:
         left_df = left_raw_df.drop(f"{left_prefix}pk", axis=1)
 
         right_raw_df = query(
-            select(
-                {cdms_source: ["pk", "crn"]},
-                engine=self.warehouse_engine,
-            ),
+            select({cdms_source: ["pk", "crn"]}, engine=self.warehouse_engine),
             resolution_name=deduper_names[cdms_source],
             return_type="pandas",
         )
         right_clusters = query_to_cluster_entities(
-            query=right_raw_df,
-            source_pks={cdms_source: f"{cdms_prefix}pk"},
+            query=right_raw_df, source_pks={cdms_source: f"{cdms_prefix}pk"}
         )
         right_df = right_raw_df.drop(f"{right_prefix}pk", axis=1)
 

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -210,7 +210,6 @@ class TestE2EAnalyticalUser:
                     + [col.name for col in source_testkit.source.columns]
                 },
                 engine=self.warehouse_engine,
-                only_indexed=False,
             )
             raw_df = query(source_select, return_type="pandas")
             clusters = query_to_cluster_entities(
@@ -290,7 +289,6 @@ class TestE2EAnalyticalUser:
                 select(
                     {left_testkit.source.address.full_name: ["pk", common_field]},
                     engine=self.warehouse_engine,
-                    only_indexed=False,
                 ),
                 resolution_name=deduper_names[left_testkit.source.address.full_name],
                 return_type="pandas",
@@ -305,7 +303,6 @@ class TestE2EAnalyticalUser:
                 select(
                     {right_testkit.source.address.full_name: ["pk", common_field]},
                     engine=self.warehouse_engine,
-                    only_indexed=False,
                 ),
                 resolution_name=deduper_names[right_testkit.source.address.full_name],
                 return_type="pandas",
@@ -403,10 +400,10 @@ class TestE2EAnalyticalUser:
             select(
                 {crn_source: ["pk", "crn"]},
                 engine=self.warehouse_engine,
-                only_indexed=False,
             ),
             select(
-                {duns_source: ["pk"]}, engine=self.warehouse_engine, only_indexed=False
+                {duns_source: ["pk"]},
+                engine=self.warehouse_engine,
             ),
             resolution_name=linker_names[first_pair],
             return_type="pandas",
@@ -421,7 +418,6 @@ class TestE2EAnalyticalUser:
             select(
                 {cdms_source: ["pk", "crn"]},
                 engine=self.warehouse_engine,
-                only_indexed=False,
             ),
             resolution_name=deduper_names[cdms_source],
             return_type="pandas",
@@ -490,7 +486,6 @@ class TestE2EAnalyticalUser:
                     cdms_source: ["pk", "crn", "cdms"],
                 },
                 engine=self.warehouse_engine,
-                only_indexed=False,
             ),
             resolution_name=final_linker_name,
             return_type="pandas",

--- a/test/server/api/test_routes.py
+++ b/test/server/api/test_routes.py
@@ -361,13 +361,15 @@ def test_query_404_source(get_backend: Mock, test_client: TestClient):
 
 @patch("matchbox.server.base.BackendManager.get_backend")
 def test_match(get_backend: Mock, test_client: TestClient):
+    foo_address = SourceAddress(full_name="foo", warehouse_hash=b"foo")
+    bar_address = SourceAddress(full_name="bar", warehouse_hash=b"bar")
     # Mock backend
     mock_matches = [
         Match(
             cluster=1,
-            source=SourceAddress(full_name="foo", warehouse_hash=b"foo"),
+            source=foo_address,
             source_id={"1"},
-            target=SourceAddress(full_name="bar", warehouse_hash=b"bar"),
+            target=bar_address,
             target_id={"a"},
         )
     ]
@@ -379,10 +381,10 @@ def test_match(get_backend: Mock, test_client: TestClient):
     response = test_client.get(
         "/match",
         params={
-            "target_full_names": ["foo"],
-            "target_warehouse_hashes_b64": [hash_to_base64(b"foo")],
-            "source_full_name": "bar",
-            "source_warehouse_hash_b64": hash_to_base64(b"bar"),
+            "target_full_names": [foo_address.full_name],
+            "target_warehouse_hashes_b64": [foo_address.warehouse_hash_b64],
+            "source_full_name": bar_address.full_name,
+            "source_warehouse_hash_b64": bar_address.warehouse_hash_b64,
             "source_pk": 1,
             "resolution_name": "res",
             "threshold": 50,
@@ -449,14 +451,15 @@ def test_match_404_source(get_backend: Mock, test_client: TestClient):
 
 @patch("matchbox.server.base.BackendManager.get_backend")
 def test_get_source(get_backend, test_client: TestClient):
-    source_testkit = Source(
-        address=SourceAddress(full_name="foo", warehouse_hash=b"bar"), db_pk="pk"
-    )
+    address = SourceAddress(full_name="foo", warehouse_hash=b"bar")
+    source = Source(address=address, db_pk="pk")
     mock_backend = Mock()
-    mock_backend.get_source = Mock(return_value=source_testkit)
+    mock_backend.get_source = Mock(return_value=source)
     get_backend.return_value = mock_backend
 
-    response = test_client.get(f"/sources/{hash_to_base64(b'bar')}/foo")
+    response = test_client.get(
+        f"/sources/{address.warehouse_hash_b64}/{address.full_name}"
+    )
     assert response.status_code == 200
     assert Source.model_validate(response.json())
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_version < '0'",
@@ -271,7 +270,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -963,7 +962,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "platform_system == 'Darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -1349,7 +1348,6 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.35" },
     { name = "tomli", marker = "extra == 'server'", specifier = ">=2.0.1" },
 ]
-provides-extras = ["server"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1457,7 +1455,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },


### PR DESCRIPTION
# Context
We want to eventually be able to support more than one configuration for the same source. Thus, the source address won't be anymore a unique identifier in our system. To avoid having to pass a point of truth twice when querying, to `mb.select()` as well as `mb.query()`, selecting doesn't fetch the source anymore; that is deferred till later.

## Changes proposed in this pull request

* `Selector` does not hold a source anymore, only an address and an engine
* `mb.select()` does not retrieve a source. Sources are retrieved by `mb.query()`
* Created `Source.check_columns()` method, and made it stronger. For example, it now checks the db_pk exists in the warehouse
* Moved `format_columns()` from `Source` to `SourceAddress`
* Moved the only_indexed parameter from `select()` to `query()` and flipped its behaviour. By default, it's set to False, and won't complain. If set to True (which is done by a DAG runner), it will raise an Exception rather than a warning). This is because there are many pitfalls to using the lower-level interface for running models, and I believe we should push users to use the DAG interface instead.
* Created pattern for making a source testkit out of value tuples, instead of feature config

## Guidance to review

* To make tests easier to write, I moved the column validation for a source outside of `set_engine()`. Now, columns are validated whenever a method that needs the engine is called. What do you think?
* Previously, a DAG step was able to avoid querying a source config from the server. Now it must, even though in theory it could reuse the same source that was created locally. Thoughts?

## Relevant links

None relevant.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation