### PR TITLE
Fix/polars on m1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "splink>=4.0.5,<4.1.0",
     "sqlalchemy>=2.0.35",
     "rich>=13.9.4",
-    "polars-lts-cpu>=1.20.0",
+    "polars-lts-cpu>=1.26.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "splink>=4.0.5,<4.1.0",
     "sqlalchemy>=2.0.35",
     "rich>=13.9.4",
-    "polars>=1.20.0",
+    "polars-lts-cpu>=1.20.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dev = [
 ]
 typing = [
     "boto3-stubs[s3]>=1.35.99",
-    "polars>=1.11.0",
     "pyarrow-stubs>=17.16",
 ]
 

--- a/src/matchbox/server/postgresql/utils/query.py
+++ b/src/matchbox/server/postgresql/utils/query.py
@@ -1,6 +1,6 @@
 """Utilities for querying and matching in the PostgreSQL backend."""
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TypeVar
 
 import pyarrow as pa
 from sqlalchemy import BIGINT, Engine, and_, cast, func, literal, null, select, union
@@ -20,11 +20,6 @@ from matchbox.server.postgresql.orm import (
     Resolutions,
     Sources,
 )
-
-if TYPE_CHECKING:
-    from polars import DataFrame as PolarsDataFrame
-else:
-    PolarsDataFrame = Any
 
 T = TypeVar("T")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1336,7 +1336,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.9.2" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pg-bulk-ingest", marker = "extra == 'server'", specifier = ">=0.0.54" },
-    { name = "polars-lts-cpu", specifier = ">=1.20.0" },
+    { name = "polars-lts-cpu", specifier = ">=1.26.0" },
     { name = "psycopg2", specifier = ">=2.9.10" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pydantic", specifier = ">=2.9.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1274,7 +1274,7 @@ dependencies = [
     { name = "httpx" },
     { name = "matplotlib" },
     { name = "pandas" },
-    { name = "polars" },
+    { name = "polars-lts-cpu" },
     { name = "psycopg2" },
     { name = "pyarrow" },
     { name = "pydantic" },
@@ -1336,7 +1336,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.9.2" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pg-bulk-ingest", marker = "extra == 'server'", specifier = ">=0.0.54" },
-    { name = "polars", specifier = ">=1.20.0" },
+    { name = "polars-lts-cpu", specifier = ">=1.20.0" },
     { name = "psycopg2", specifier = ">=2.9.10" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pydantic", specifier = ">=2.9.2" },
@@ -1890,6 +1890,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/33/1970863f0c1782a916299346d150c5bb8373d4e6827fabb8c37a0a2bcb8e/polars-1.20.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:d488ffb92d4934d9c326fa2d0fb2e9a4e3c2c625c59f4a77a77e4acd4d5a0d66", size = 29885148 },
     { url = "https://files.pythonhosted.org/packages/bb/2d/b29112da3e98ba55e8ba77f08a90312004d2e4be0fd6401ff7d5d71eae0a/polars-1.20.0-cp39-abi3-win_amd64.whl", hash = "sha256:5ce417d2b6d4f3b8f422fcb3482039e8076182cceacbd880175fe970c6f99c84", size = 32947632 },
     { url = "https://files.pythonhosted.org/packages/60/da/245e5852342cab10c48dc788f7b3d39a1f926f783ea124f196ad783ea6aa/polars-1.20.0-cp39-abi3-win_arm64.whl", hash = "sha256:f474f3d65450138cd2dbab2d9b6041b8646c30fad0b28e6d62457788f994bf62", size = 29141207 },
+]
+
+[[package]]
+name = "polars-lts-cpu"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/ae/812e90a471a5119384895f08f7999278fedd35e828c9dd786717e88c624d/polars_lts_cpu-1.26.0.tar.gz", hash = "sha256:639939cf66f7cf6fbcac05a13155dd5400f944d3d6afef06797e3161b24041c6", size = 4522065 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/db/605c802b832363128b120810c7679c431da90cc71f586c16213acdc999ec/polars_lts_cpu-1.26.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6366b3b6ddd9ee6560c4d804c44e419691bb564c44bcc848e1f2e49b7cf0b41e", size = 34416600 },
+    { url = "https://files.pythonhosted.org/packages/b4/be/3fdc967ad3a96f98fa47d9f337b8812af3c5eee46a3a65d9249c74d3296d/polars_lts_cpu-1.26.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:59e65c9559a12f35164344f7b0a70e35e8630a0ebb824be6913a36772bbaa63b", size = 31612485 },
+    { url = "https://files.pythonhosted.org/packages/61/c5/6b6149c1200ad024e85ac65bc2157d4139eecc45f1e2ced54801a3f86415/polars_lts_cpu-1.26.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b6a6895057235e9dd372c9e2b872c9c30cb63842c57e573f9be53b06cf8576b", size = 35038341 },
+    { url = "https://files.pythonhosted.org/packages/fd/b3/a66d2ce1b80e048097485cd4f49f8681fb8c5be4efe289726da8e74faafb/polars_lts_cpu-1.26.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:4be8bb96ede7fdf3f1468348b537edaca3dfcbf12bd4ea935b8c39b0afef6f2f", size = 32569875 },
+    { url = "https://files.pythonhosted.org/packages/8d/cc/92ef50d557e3bfb408163028455def22d541c3e78389fec9dd1e72e9ab4b/polars_lts_cpu-1.26.0-cp39-abi3-win_amd64.whl", hash = "sha256:2e5eb75bd3eb69b7cf6f30038602a15945e0b6a71db4fb4aaa6f101bd5d1648a", size = 35448140 },
+    { url = "https://files.pythonhosted.org/packages/5c/1c/6f72e9790f1b7c81079a6152f7049eb5909f02749b06b6e475e4517d2709/polars_lts_cpu-1.26.0-cp39-abi3-win_arm64.whl", hash = "sha256:26b6e9a116c8385cab75bca3161dba03dffe167edecd21c8125fe5974400c417", size = 31896017 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1318,7 +1318,6 @@ dev = [
 ]
 typing = [
     { name = "boto3-stubs", extra = ["s3"] },
-    { name = "polars" },
     { name = "pyarrow-stubs" },
 ]
 
@@ -1372,7 +1371,6 @@ dev = [
 ]
 typing = [
     { name = "boto3-stubs", extras = ["s3"], specifier = ">=1.35.99" },
-    { name = "polars", specifier = ">=1.11.0" },
     { name = "pyarrow-stubs", specifier = ">=17.16" },
 ]
 
@@ -1876,20 +1874,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
-]
-
-[[package]]
-name = "polars"
-version = "1.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/8f/1005f24c8c413d8a393973fcb45e6085a2311bb513ee0c6674d438e99c31/polars-1.20.0.tar.gz", hash = "sha256:e8e9e3156fae02b58e276e5f2c16a5907a79b38617a9e2d731b533d87798f451", size = 4292434 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/ef/74d56f82bc2e7911276ffad8f24e7ae6f7a102ecab3b2e88b87e84243356/polars-1.20.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9a313e10ea80b99a0d32bfb942b2260b9658155287b0c2ac5876323acaff4f2c", size = 32143323 },
-    { url = "https://files.pythonhosted.org/packages/dd/e1/51c7b2bc3037af89f1c109b61a2d2f44c411212df63dd0e9c6683b66d98e/polars-1.20.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4474bd004376599f7e4906bd350026cbbe805ba604121090578a97f63da15381", size = 28954418 },
-    { url = "https://files.pythonhosted.org/packages/2a/1a/862b8bf65182b261022292a1cd49728db876a1ef64ff377d6f7b17653886/polars-1.20.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4996e17cb6f57d9aeaf79f66c54ef2913cea7bd025410c076ef8c05d4f7d792a", size = 32850943 },
-    { url = "https://files.pythonhosted.org/packages/b7/33/1970863f0c1782a916299346d150c5bb8373d4e6827fabb8c37a0a2bcb8e/polars-1.20.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:d488ffb92d4934d9c326fa2d0fb2e9a4e3c2c625c59f4a77a77e4acd4d5a0d66", size = 29885148 },
-    { url = "https://files.pythonhosted.org/packages/bb/2d/b29112da3e98ba55e8ba77f08a90312004d2e4be0fd6401ff7d5d71eae0a/polars-1.20.0-cp39-abi3-win_amd64.whl", hash = "sha256:5ce417d2b6d4f3b8f422fcb3482039e8076182cceacbd880175fe970c6f99c84", size = 32947632 },
-    { url = "https://files.pythonhosted.org/packages/60/da/245e5852342cab10c48dc788f7b3d39a1f926f783ea124f196ad783ea6aa/polars-1.20.0-cp39-abi3-win_arm64.whl", hash = "sha256:f474f3d65450138cd2dbab2d9b6041b8646c30fad0b28e6d62457788f994bf62", size = 29141207 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Context
When building a Docker image, connectorx needs the `linux/amd` platform, or no matching wheel will be found. On Mac M* chips, that will trigger Rosetta (virtualisation), which breaks Polars, preventing the API from starting up. The only way to use Polars is to install the (slower) distribution which is compiled to be run on old CPUs.

## Changes proposed in this pull request

* Replace polars dependency with `polars-lts-cpu` and bump to 1.26
* Remove unused references to polars

## Guidance to review

This is an interim solution until one of the following happens:

* Connectorx gets its act together
* We drop Connectorx
* We decide to separate docker image and local dev requirements, which essentially means separate pyproject.toml and requirements files

## Relevant links

* https://pypi.org/project/polars-lts-cpu/, very bottom of the page, under the "Legacy" heading
* [Connectorx open PR to fix this issue](https://github.com/sfu-db/connector-x/pull/781)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation