### PR TITLE
Use git tags to dynamically infer version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "matchbox-db"
-version = "0.0.0.dev0"
+dynamic = ["version"]
 description = "A framework for orchestrating and comparing data linking and deduplication methodologies."
 authors = [{ name="Department for Business and Trade" }]
 license = {file = "LICENSE"}
@@ -67,8 +67,11 @@ typing = [
 "Repository" = "https://github.com/uktrade/matchbox.git"
 
 [build-system]
-requires = ["setuptools>=42"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+
 
 [tool.uv]
 default-groups = ["dev", "typing"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ typing = [
 requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
+# Presence enables setuptools-scm
 [tool.setuptools_scm]
 
 

--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -25,6 +25,12 @@ COPY ./src/matchbox /code/src/matchbox
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
 RUN --mount=type=cache,target=/root/.cache/uv \
+    # Determine package version dynamically from the git tag
+    --mount=source=.git,target=/code/.git,type=bind \
+    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MATCHBOX_DB=$(git describe --tags | \
+        # Change the first dash to a plus sign and the rest to dots
+        # This is a workaround for setuptools_scm not supporting dashes in version numbers
+        awk '{sub("-", "+"); gsub("-", "."); print}') \
     uv sync --frozen --all-extras --no-dev
 
 # Place executables in the environment at the front of the path

--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -27,10 +27,7 @@ COPY ./src/matchbox /code/src/matchbox
 RUN --mount=type=cache,target=/root/.cache/uv \
     # Determine package version dynamically from the git tag
     --mount=source=.git,target=/code/.git,type=bind \
-    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MATCHBOX_DB=$(git describe --tags | \
-        # Change the first dash to a plus sign and the rest to dots
-        # This is a workaround for setuptools_scm not supporting dashes in version numbers
-        awk '{sub("-", "+"); gsub("-", "."); print}') \
+    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MATCHBOX_DB=$(uv run python -m  setuptools_scm) \
     uv sync --frozen --all-extras --no-dev
 
 # Place executables in the environment at the front of the path

--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ wheels = [
 
 [[package]]
 name = "matchbox-db"
-version = "0.2.5.dev75+g366194a.d20250402"
+version = "0.2.5.dev76+g7d4fcd8.d20250402"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ wheels = [
 
 [[package]]
 name = "matchbox-db"
-version = "0.2.5.dev74+g1edb784.d20250402"
+version = "0.2.5.dev75+g366194a.d20250402"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ wheels = [
 
 [[package]]
 name = "matchbox-db"
-version = "0.2.5.dev76+g7d4fcd8.d20250402"
+version = "0.2.5.dev77+ga860b7c.d20250402"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_version < '0'",
@@ -271,7 +270,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -963,7 +962,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "platform_system == 'Darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -1264,7 +1263,7 @@ wheels = [
 
 [[package]]
 name = "matchbox-db"
-version = "0.0.0.dev0"
+version = "0.2.5.dev74+g1edb784.d20250402"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1348,7 +1347,6 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.35" },
     { name = "tomli", marker = "extra == 'server'", specifier = ">=2.0.1" },
 ]
-provides-extras = ["server"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1455,7 +1453,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },


### PR DESCRIPTION
# Context

## Changes proposed in this pull request

* Added setuptools-scm as a build dependency
* Made the version dynamic in pyproject.toml
* Updated the Dockerfile to temporarily mount .git and use git describe to determine the current tag when building the image

## Guidance to review

* I believe every commit will now update the uv.lock, which is a bit annoying, but not much noisier than it is already? I suppose the alternative is to set up a custom version generator for setuptools-scm that just says something like 0.2.5+DEV instead of the full commit hash and date
* It also, by default, increments the version automatically in a speculative manner. E.g. if the current tag is 0.2.4, and your git repo is dirty, it will say it's a dev version of 0.2.5

## Relevant links

* Took inspiration from: https://setuptools-scm.readthedocs.io/en/latest/usage/#with-dockerpodman

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation