### PR TITLE
Quick fix for httpx timeouts

### DIFF
--- a/src/matchbox/client/_handler.py
+++ b/src/matchbox/client/_handler.py
@@ -96,7 +96,7 @@ def create_client(settings: ClientSettings) -> httpx.Client:
     """Create an HTTPX client with proper configuration."""
     return httpx.Client(
         base_url=settings.api_root,
-        timeout=settings.timeout,
+        timeout=httpx.Timeout(60 * 30, connect=settings.timeout, pool=settings.timeout),
         event_hooks={"response": [handle_http_code]},
         headers=create_headers(settings),
     )

--- a/test/client/test_helpers.py
+++ b/test/client/test_helpers.py
@@ -89,7 +89,10 @@ def test_create_client():
 
     assert client.headers.get("X-Matchbox-Client-Version") == version("matchbox_db")
     assert client.base_url == mock_settings.api_root
-    assert client.timeout.read == mock_settings.timeout
+    assert client.timeout.connect == mock_settings.timeout
+    assert client.timeout.pool == mock_settings.timeout
+    assert client.timeout.read == 60 * 30
+    assert client.timeout.write == 60 * 30
 
 
 def test_select_default_engine(


### PR DESCRIPTION
# Context

## Changes proposed in this pull request

* Settable timeout for the client only affects connection and pool
* Read and write timeouts are hardcoded to 30 minutes

## Guidance to review
Are the hardcoded timeouts too short?

## Relevant links

* https://www.python-httpx.org/advanced/timeouts/

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've changed or updated relevant documentation