### PR TITLE
Add Matchbox IDs to SQL interface

### DIFF
--- a/src/matchbox/client/extract.py
+++ b/src/matchbox/client/extract.py
@@ -13,7 +13,7 @@ def _create_view_definition(
     mapping_table: str,
     engine: Engine,
 ) -> str:
-    selection = []
+    selection = [text("id")]
 
     for cn in column_names:
         selection.append(

--- a/src/matchbox/client/extract.py
+++ b/src/matchbox/client/extract.py
@@ -28,6 +28,7 @@ def _create_view_definition(
             func.cast(text(f"{table_name}.{db_pk}"), String)
             == func.cast(text(f"{mapping_table}.{table_name}_{db_pk}"), String),
             isouter=True,
+            full=True,
         )
 
     return str(query.compile(dialect=engine.dialect))

--- a/test/client/test_extract.py
+++ b/test/client/test_extract.py
@@ -40,10 +40,10 @@ def test_sql_interface(
     # Because of FULL OUTER JOIN, we expect some values to be null, and some explosions
     df_expected = pl.DataFrame(
         [
-            {"foo_pk": 1, "bar_pk": "a", "foo_col": 0, "bar_col": 10},
-            {"foo_pk": 2, "bar_pk": None, "foo_col": 1, "bar_col": None},
-            {"foo_pk": 3, "bar_pk": "b", "foo_col": 2, "bar_col": 11},
-            {"foo_pk": 3, "bar_pk": "c", "foo_col": 2, "bar_col": 12},
+            {"id": 1, "foo_pk": 1, "bar_pk": "a", "foo_col": 0, "bar_col": 10},
+            {"id": 2, "foo_pk": 2, "bar_pk": None, "foo_col": 1, "bar_col": None},
+            {"id": 3, "foo_pk": 3, "bar_pk": "b", "foo_col": 2, "bar_col": 11},
+            {"id": 3, "foo_pk": 3, "bar_pk": "c", "foo_col": 2, "bar_col": 12},
         ]
     )
 


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

* Matchbox IDs were not made available to the SQL view. That meant you couldn't deduplicate a single table. This is now fixed.

## 👀 Guidance to review
None

## 🤖 AI declaration
None

## 🔗 Relevant links
None

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation
