### PR TITLE
Temporarily turn sql interface to single mapping table

### DIFF
--- a/src/matchbox/client/extract.py
+++ b/src/matchbox/client/extract.py
@@ -1,62 +1,21 @@
 """Functions to extract data out of the Matchbox server."""
 
 from pyarrow import Table as ArrowTable
-from sqlalchemy import Engine, String, func, select, text
+from sqlalchemy import Engine
 
 from matchbox.client import _handler
 from matchbox.common.sources import Source, SourceAddress
-
-
-def _create_view_definition(
-    column_names: list[dict[str, str]],
-    db_pks: dict[str, str],
-    mapping_table: str,
-    engine: Engine,
-) -> str:
-    selection = []
-
-    for cn in column_names:
-        selection.append(
-            text(f"{cn['table_name']}.{cn['column_name']} as {cn['combined_name']}")
-        )
-
-    query = select(*selection).select_from(text(mapping_table))
-
-    for table_name, db_pk in db_pks.items():
-        query = query.join(
-            text(table_name),
-            func.cast(text(f"{table_name}.{db_pk}"), String)
-            == func.cast(text(f"{mapping_table}.{table_name}_{db_pk}"), String),
-            isouter=True,
-        )
-
-    return str(query.compile(dialect=engine.dialect))
 
 
 def _combined_colname(source: Source, col_name: str):
     return source.address.full_name.replace(".", "_") + "_" + col_name
 
 
-def sql_interface(
+def primary_keys_map(
     resolution_name: str,
     engine: Engine,
-    mapping_table: str,
-) -> tuple[ArrowTable, ArrowTable, str]:
-    """Generate snapshot and DDL implmenting SQL interface to results.
-
-    Args:
-        resolution_name: Name of the resolution from which to generate results
-        engine: SQLAlchemy engine of warehouse running SQL interface
-        mapping_table: The name (+ schema) where the mapping table will be written.
-
-    Returns:
-        A tuple of 3 items containing:
-
-            * A PyArrow table mapping from Matchbox IDs to all source PKs
-            * A PyArrow table mapping sources and columns to column names in the view
-            * The DQL definition of a view to use for querying results in SQL
-
-    """
+) -> ArrowTable:
+    """Return table mapping matchbox IDs to source IDs accessible by an engine."""
     # Get all sources in scope of the resolution
     res_sources = _handler.get_resolution_sources(resolution_name=resolution_name)
 
@@ -72,7 +31,6 @@ def sql_interface(
     ]
 
     source_mb_ids: list[ArrowTable] = []
-    column_names: list[dict[str, str]] = []
     db_pks: dict[str, str] = {}
 
     for s in sources:
@@ -83,17 +41,6 @@ def sql_interface(
                 resolution_name=resolution_name,
             )
         )
-        # Get remote columns from warehouse
-        cols = s.get_remote_columns()
-        column_names += [
-            {
-                "table_name": s.address.full_name,
-                "column_name": c,
-                "combined_name": _combined_colname(s, c),
-                "db_pk": s.db_pk,
-            }
-            for c in cols
-        ]
 
         db_pks[s.address.full_name] = s.db_pk
 
@@ -112,15 +59,4 @@ def sql_interface(
             {"source_pk": _combined_colname(s, db_pks[s.address.full_name])}
         )
 
-    # Get SQL query for view
-    view_definition = _create_view_definition(
-        column_names=column_names,
-        db_pks=db_pks,
-        mapping_table=mapping_table,
-        engine=engine,
-    )
-
-    # Convert column names dataframe
-    column_names = ArrowTable.from_pylist(column_names)
-
-    return mapping, column_names, view_definition
+    return mapping

--- a/test/client/test_extract.py
+++ b/test/client/test_extract.py
@@ -3,9 +3,9 @@ import pyarrow as pa
 from httpx import Response
 from polars.testing import assert_frame_equal
 from respx import MockRouter
-from sqlalchemy import Engine, create_engine, text
+from sqlalchemy import Engine, create_engine
 
-from matchbox.client.extract import sql_interface
+from matchbox.client.extract import primary_keys_map
 from matchbox.common.arrow import SCHEMA_MB_IDS, table_to_buffer
 from matchbox.common.factories.sources import source_from_tuple
 
@@ -38,12 +38,12 @@ def test_sql_interface(
     bar.to_warehouse(sqlite_warehouse)
 
     # Because of FULL OUTER JOIN, we expect some values to be null, and some explosions
-    df_expected = pl.DataFrame(
+    expected_mapping = pl.DataFrame(
         [
-            {"foo_pk": 1, "bar_pk": "a", "foo_col": 0, "bar_col": 10},
-            {"foo_pk": 2, "bar_pk": None, "foo_col": 1, "bar_col": None},
-            {"foo_pk": 3, "bar_pk": "b", "foo_col": 2, "bar_col": 11},
-            {"foo_pk": 3, "bar_pk": "c", "foo_col": 2, "bar_col": 12},
+            {"id": 1, "foo_pk": "1", "bar_pk": "a"},
+            {"id": 2, "foo_pk": "2", "bar_pk": None},
+            {"id": 3, "foo_pk": "3", "bar_pk": "b"},
+            {"id": 3, "foo_pk": "3", "bar_pk": "c"},
         ]
     )
 
@@ -93,35 +93,11 @@ def test_sql_interface(
     )
 
     # Call extracting method
-    mapping, column_names, view_definition = sql_interface(
-        resolution_name="companies",
-        engine=sqlite_warehouse,
-        mapping_table="companies_matches",
+    mapping = primary_keys_map(resolution_name="companies", engine=sqlite_warehouse)
+
+    assert_frame_equal(
+        pl.from_arrow(mapping),
+        expected_mapping,
+        check_row_order=False,
+        check_column_order=False,
     )
-
-    # Check column names are as expected
-    col_n_df = column_names.to_pandas()
-    assert set(col_n_df["table_name"].tolist()) == {"foo", "bar"}
-    assert set(col_n_df["column_name"].tolist()) == {"col", "pk"}
-    assert set(col_n_df["db_pk"].tolist()) == {"pk"}
-    assert set(col_n_df["combined_name"].tolist()) == {
-        "foo_col",
-        "bar_col",
-        "foo_pk",
-        "bar_pk",
-    }
-
-    # Write results to the warehouse
-    with sqlite_warehouse.connect() as conn:
-        pl.from_arrow(mapping).write_database("companies_matches", conn)
-        pl.from_arrow(column_names).write_database("companies_columns", conn)
-        conn.execute(text(f"CREATE VIEW companies AS {view_definition}"))
-        conn.commit()
-
-        # Check SQL interface works as intended
-        test_query = "SELECT * FROM companies"
-        df_actual = pl.read_database(test_query, connection=conn)
-
-        assert_frame_equal(
-            df_actual, df_expected, check_row_order=False, check_column_order=False
-        )


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

* Remove `matchbox.client.extract.sql_interface`, replacing it with a simpler `matchbox.client.extract.primary_key_map`

## 👀 Guidance to review

This is a temporary measure. Further tickets have been created to implement next steps:

- https://uktrade.atlassian.net/browse/MTCHBX-309?atlOrigin=eyJpIjoiOGY1MWVjZWZmZTdmNGYxZDhkOTE0OGQ0ZWJjMTViYmUiLCJwIjoiaiJ9
- https://uktrade.atlassian.net/browse/MTCHBX-310?atlOrigin=eyJpIjoiMzMzMmQxZGE4ZTI1NDUwMGExYzhiMTI1ODFkZGVkMmIiLCJwIjoiaiJ9

## 🤖 AI declaration

None

## 🔗 Relevant links

None

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation
