### PR TITLE
Handle edge cases around SQL interface auxiliary functions

### DIFF
--- a/src/matchbox/server/postgresql/adapter.py
+++ b/src/matchbox/server/postgresql/adapter.py
@@ -215,11 +215,13 @@ class MatchboxPostgres(MatchboxDBAdapter):
     ) -> list[Source]:
         with MBDB.get_session() as session:
             # Find resolution by name
-            resolution: Resolutions = (
+            resolution: Resolutions | None = (
                 session.query(Resolutions)
                 .filter(Resolutions.name == resolution_name)
                 .first()
             )
+            if not resolution:
+                raise MatchboxResolutionNotFoundError(resolution_name=resolution_name)
             # Find all resolutions in scope (selected + ancestors)
             relevant_resolutions = (
                 session.query(Resolutions)

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -425,7 +425,7 @@ class TestE2EAnalyticalUser:
         right_cleaned = _clean_company_name(right_df, cdms_prefix)
 
         # Create and run final linker with the common "crn" field
-        final_linker_name = "final_linker"
+        final_linker_name = "__DEFAULT__"
         final_linker = make_model(
             model_name=final_linker_name,
             description="Final linking of all sources",

--- a/test/server/test_adapter.py
+++ b/test/server/test_adapter.py
@@ -146,6 +146,9 @@ class TestMatchboxBackend:
                 duns.source.resolution_name,
             }
 
+            with pytest.raises(MatchboxResolutionNotFoundError):
+                self.backend.get_resolution_sources(resolution_name="nonexistent")
+
     def test_get_resolution_graph(self):
         """Test getting the resolution graph."""
         graph = self.backend.get_resolution_graph()


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

* Support generating mapping for a single source
* Error explicitly when no source is available
* Make engine filter optional (no longer needed)
* Error explicitly when resolution matching name isn't found

## 👀 Guidance to review

I changed the name of a linker in the e2e tests because it makes it simpler to test the AirFlow pipeline.

## 🤖 AI declaration

None
## 🔗 Relevant links

None

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation
