### PR TITLE
Improve deletion of resolutions

### DIFF
--- a/src/matchbox/client/_handler.py
+++ b/src/matchbox/client/_handler.py
@@ -15,8 +15,8 @@ from matchbox.common.dtos import (
     BackendRetrievableType,
     ModelAncestor,
     ModelMetadata,
-    ModelOperationStatus,
     NotFoundError,
+    ResolutionOperationStatus,
     UploadStatus,
 )
 from matchbox.common.exceptions import (
@@ -83,7 +83,7 @@ def handle_http_code(res: httpx.Response) -> httpx.Response:
             raise RuntimeError(f"Unexpected 404 error: {error.details}")
 
     if res.status_code == 409:
-        error = ModelOperationStatus.model_validate(res.json())
+        error = ResolutionOperationStatus.model_validate(res.json())
         raise MatchboxDeletionNotConfirmed(message=error.details)
 
     if res.status_code == 422:
@@ -270,13 +270,13 @@ def get_resolution_graph() -> ResolutionGraph:
 # Model management
 
 
-def insert_model(model: ModelMetadata) -> ModelOperationStatus:
+def insert_model(model: ModelMetadata) -> ResolutionOperationStatus:
     """Insert a model in Matchbox."""
     log_prefix = f"Model {model.name}"
     logger.debug("Inserting metadata", prefix=log_prefix)
 
     res = CLIENT.post("/models", json=model.model_dump())
-    return ModelOperationStatus.model_validate(res.json())
+    return ResolutionOperationStatus.model_validate(res.json())
 
 
 def get_model(name: str) -> ModelMetadata:
@@ -336,13 +336,13 @@ def get_model_results(name: str) -> Table:
     return read_table(buffer)
 
 
-def set_model_truth(name: str, truth: int) -> ModelOperationStatus:
+def set_model_truth(name: str, truth: int) -> ResolutionOperationStatus:
     """Set the truth threshold for a model in Matchbox."""
     log_prefix = f"Model {name}"
     logger.debug("Setting truth value", prefix=log_prefix)
 
     res = CLIENT.patch(f"/models/{name}/truth", json=truth)
-    return ModelOperationStatus.model_validate(res.json())
+    return ResolutionOperationStatus.model_validate(res.json())
 
 
 def get_model_truth(name: str) -> int:
@@ -365,7 +365,7 @@ def get_model_ancestors(name: str) -> list[ModelAncestor]:
 
 def set_model_ancestors_cache(
     name: str, ancestors: list[ModelAncestor]
-) -> ModelOperationStatus:
+) -> ResolutionOperationStatus:
     """Set the ancestors cache for a model in Matchbox."""
     log_prefix = f"Model {name}"
     logger.debug("Setting ancestors cached truth values", prefix=log_prefix)
@@ -374,7 +374,7 @@ def set_model_ancestors_cache(
         f"/models/{name}/ancestors_cache",
         json=[a.model_dump() for a in ancestors],
     )
-    return ModelOperationStatus.model_validate(res.json())
+    return ResolutionOperationStatus.model_validate(res.json())
 
 
 def get_model_ancestors_cache(name: str) -> list[ModelAncestor]:
@@ -386,10 +386,10 @@ def get_model_ancestors_cache(name: str) -> list[ModelAncestor]:
     return [ModelAncestor.model_validate(m) for m in res.json()]
 
 
-def delete_model(name: str, certain: bool = False) -> ModelOperationStatus:
-    """Delete a model in Matchbox."""
+def delete_resolution(name: str, certain: bool = False) -> ResolutionOperationStatus:
+    """Delete a resolution in Matchbox."""
     log_prefix = f"Model {name}"
     logger.debug("Deleting", prefix=log_prefix)
 
-    res = CLIENT.delete(f"/models/{name}", params={"certain": certain})
-    return ModelOperationStatus.model_validate(res.json())
+    res = CLIENT.delete(f"/resolutions/{name}", params={"certain": certain})
+    return ResolutionOperationStatus.model_validate(res.json())

--- a/src/matchbox/client/models/models.py
+++ b/src/matchbox/client/models/models.py
@@ -91,7 +91,7 @@ class Model:
 
     def delete(self, certain: bool = False) -> bool:
         """Delete the model from the database."""
-        result = _handler.delete_model(name=self.metadata.name, certain=certain)
+        result = _handler.delete_resolution(name=self.metadata.name, certain=certain)
         return result.success
 
     def run(self) -> Results:

--- a/src/matchbox/common/dtos.py
+++ b/src/matchbox/common/dtos.py
@@ -64,12 +64,11 @@ class ModelType(StrEnum):
     DEDUPER = "deduper"
 
 
-class ModelOperationType(StrEnum):
-    """Enumeration of supported model operations."""
+class CRUDOperation(StrEnum):
+    """Enumeration of CRUD operations."""
 
-    INSERT = "insert"
-    UPDATE_TRUTH = "update_truth"
-    UPDATE_ANCESTOR_CACHE = "update_ancestor_cache"
+    CREATE = "create"
+    UPDATE = "update"
     DELETE = "delete"
 
 
@@ -92,12 +91,12 @@ class ModelAncestor(BaseModel):
     )
 
 
-class ModelOperationStatus(BaseModel):
-    """Status response for any model operation."""
+class ResolutionOperationStatus(BaseModel):
+    """Status response for any resolution operation."""
 
     success: bool
-    model_name: str
-    operation: ModelOperationType
+    resolution_name: str
+    operation: CRUDOperation
     details: str | None = None
 
     @classmethod
@@ -111,8 +110,8 @@ class ModelOperationStatus(BaseModel):
                             "summary": "Delete operation requires confirmation. ",
                             "value": cls(
                                 success=False,
-                                model_name="example_model",
-                                operation=ModelOperationType.DELETE,
+                                resolution_name="example_model",
+                                operation=CRUDOperation.DELETE,
                                 details=(
                                     "This operation will delete the resolutions "
                                     "deduper_1, deduper_2, linker_1, "
@@ -144,8 +143,8 @@ class ModelOperationStatus(BaseModel):
                             ),
                             "value": cls(
                                 success=False,
-                                model_name="example_model",
-                                operation=ModelOperationType.UPDATE_TRUTH,
+                                resolution_name="example_model",
+                                operation=CRUDOperation.UPDATE,
                             ).model_dump(),
                         },
                     },

--- a/src/matchbox/server/api/main.py
+++ b/src/matchbox/server/api/main.py
@@ -42,7 +42,7 @@ from matchbox.server.api.dependencies import (
     lifespan,
     validate_api_key,
 )
-from matchbox.server.api.routers import models, sources
+from matchbox.server.api.routers import models, resolutions, sources
 
 app = FastAPI(
     title="matchbox API",
@@ -51,6 +51,7 @@ app = FastAPI(
 )
 app.include_router(models.router)
 app.include_router(sources.router)
+app.include_router(resolutions.router)
 
 
 @app.exception_handler(StarletteHTTPException)

--- a/src/matchbox/server/api/routers/resolutions.py
+++ b/src/matchbox/server/api/routers/resolutions.py
@@ -1,0 +1,67 @@
+"""Resolutions API routes for the Matchbox server."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from matchbox.common.dtos import (
+    BackendRetrievableType,
+    CRUDOperation,
+    NotFoundError,
+    ResolutionOperationStatus,
+)
+from matchbox.common.exceptions import (
+    MatchboxDeletionNotConfirmed,
+    MatchboxResolutionNotFoundError,
+)
+from matchbox.server.api.dependencies import (
+    BackendDependency,
+    validate_api_key,
+)
+
+router = APIRouter(prefix="/resolutions", tags=["resolutions"])
+
+
+@router.delete(
+    "/{name}",
+    responses={
+        404: {"model": NotFoundError},
+        409: {
+            "model": ResolutionOperationStatus,
+            **ResolutionOperationStatus.status_409_examples(),
+        },
+    },
+    dependencies=[Depends(validate_api_key)],
+)
+async def delete_resolution(
+    backend: BackendDependency,
+    name: str,
+    certain: Annotated[
+        bool, Query(description="Confirm deletion of the model")
+    ] = False,
+) -> ResolutionOperationStatus:
+    """Delete a model from the backend."""
+    try:
+        backend.delete_resolution(resolution=name, certain=certain)
+        return ResolutionOperationStatus(
+            success=True,
+            resolution_name=name,
+            operation=CRUDOperation.DELETE,
+        )
+    except MatchboxResolutionNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=NotFoundError(
+                details=str(e), entity=BackendRetrievableType.RESOLUTION
+            ).model_dump(),
+        ) from e
+    except MatchboxDeletionNotConfirmed as e:
+        raise HTTPException(
+            status_code=409,
+            detail=ResolutionOperationStatus(
+                success=False,
+                resolution_name=name,
+                operation=CRUDOperation.DELETE,
+                details=str(e),
+            ).model_dump(),
+        ) from e

--- a/src/matchbox/server/base.py
+++ b/src/matchbox/server/base.py
@@ -467,11 +467,11 @@ class MatchboxDBAdapter(ABC):
         ...
 
     @abstractmethod
-    def delete_model(self, model: str, certain: bool) -> None:
-        """Delete a model from the database.
+    def delete_resolution(self, resolution: str, certain: bool) -> None:
+        """Delete a resolution from the database.
 
         Args:
-            model: The name of the model to delete.
+            resolution: The name of the resolution to delete.
             certain: Whether to delete the model without confirmation.
         """
         ...

--- a/src/matchbox/server/postgresql/adapter.py
+++ b/src/matchbox/server/postgresql/adapter.py
@@ -477,7 +477,7 @@ class MatchboxPostgres(MatchboxDBAdapter):
             ]
 
     def delete_resolution(self, resolution: str, certain: bool = False) -> None:  # noqa: D102
-        resolution = Resolutions.from_name(resolution_name=resolution, res_type="model")
+        resolution = Resolutions.from_name(resolution_name=resolution)
         with MBDB.get_session() as session:
             session.add(resolution)
             if certain:

--- a/src/matchbox/server/postgresql/adapter.py
+++ b/src/matchbox/server/postgresql/adapter.py
@@ -476,8 +476,8 @@ class MatchboxPostgres(MatchboxDBAdapter):
                 for name, truth in session.execute(query).all()
             ]
 
-    def delete_model(self, model: str, certain: bool = False) -> None:  # noqa: D102
-        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
+    def delete_resolution(self, resolution: str, certain: bool = False) -> None:  # noqa: D102
+        resolution = Resolutions.from_name(resolution_name=resolution, res_type="model")
         with MBDB.get_session() as session:
             session.add(resolution)
             if certain:

--- a/src/matchbox/server/postgresql/adapter.py
+++ b/src/matchbox/server/postgresql/adapter.py
@@ -34,7 +34,6 @@ from matchbox.server.postgresql.orm import (
 from matchbox.server.postgresql.utils.db import (
     dump,
     get_resolution_graph,
-    resolve_model_name,
     restore,
 )
 from matchbox.server.postgresql.utils.insert import (
@@ -399,11 +398,11 @@ class MatchboxPostgres(MatchboxDBAdapter):
         )
 
     def get_model(self, model: str) -> ModelMetadata:  # noqa: D102
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         return get_model_metadata(resolution=resolution)
 
     def set_model_results(self, model: str, results: Table) -> None:  # noqa: D102
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         insert_results(
             results=results,
             resolution=resolution,
@@ -411,22 +410,22 @@ class MatchboxPostgres(MatchboxDBAdapter):
         )
 
     def get_model_results(self, model: str) -> Table:  # noqa: D102
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         return get_model_results(resolution=resolution)
 
     def set_model_truth(self, model: str, truth: int) -> None:  # noqa: D102
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         with MBDB.get_session() as session:
             session.add(resolution)
             resolution.truth = truth
             session.commit()
 
     def get_model_truth(self, model: str) -> int:  # noqa: D102
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         return resolution.truth
 
     def get_model_ancestors(self, model: str) -> list[ModelAncestor]:  # noqa: D102
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         return [
             ModelAncestor(name=resolution.name, truth=resolution.truth)
             for resolution in resolution.ancestors
@@ -437,7 +436,7 @@ class MatchboxPostgres(MatchboxDBAdapter):
         model: str,
         ancestors_cache: list[ModelAncestor],
     ) -> None:
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         with MBDB.get_session() as session:
             session.add(resolution)
             ancestor_names = [ancestor.name for ancestor in ancestors_cache]
@@ -462,7 +461,7 @@ class MatchboxPostgres(MatchboxDBAdapter):
             session.commit()
 
     def get_model_ancestors_cache(self, model: str) -> list[ModelAncestor]:  # noqa: D102
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         with MBDB.get_session() as session:
             session.add(resolution)
             query = (
@@ -478,7 +477,7 @@ class MatchboxPostgres(MatchboxDBAdapter):
             ]
 
     def delete_model(self, model: str, certain: bool = False) -> None:  # noqa: D102
-        resolution = resolve_model_name(model=model)
+        resolution = Resolutions.from_name(resolution_name=model, res_type="model")
         with MBDB.get_session() as session:
             session.add(resolution)
             if certain:

--- a/src/matchbox/server/postgresql/orm.py
+++ b/src/matchbox/server/postgresql/orm.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.dialects.postgresql import BYTEA, TEXT, insert
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Session, relationship
 
 from matchbox.common.exceptions import (
     MatchboxResolutionNotFoundError,
@@ -77,7 +77,6 @@ class Resolutions(CountMixin, MBDB.MatchboxBase):
     probabilities = relationship(
         "Probabilities",
         back_populates="proposed_by",
-        cascade="all, delete-orphan",
         passive_deletes=True,
     )
     children = relationship(
@@ -177,28 +176,35 @@ class Resolutions(CountMixin, MBDB.MatchboxBase):
         cls,
         resolution_name: str,
         res_type: Literal["model", "dataset", "human"] | None = None,
+        session: Session | None = None,
     ) -> "Resolutions":
         """Resolves a model name to a Resolution object.
 
         Args:
             resolution_name: The name of the model to resolve.
             res_type: A resolution type to use as filter.
+            session: A session to get the resolution for updates.
 
         Raises:
             MatchboxResolutionNotFoundError: If the model doesn't exist.
         """
-        with MBDB.get_session() as session:
-            query = select(cls).where(cls.name == resolution_name)
-            if res_type:
-                query = query.where(cls.type == res_type)
+        query = select(cls).where(cls.name == resolution_name)
+        if res_type:
+            query = query.where(cls.type == res_type)
 
-            if resolution := session.execute(query).scalar():
-                return resolution
+        if session:
+            resolution = session.execute(query).scalar()
+        else:
+            with MBDB.get_session() as session:
+                resolution = session.execute(query).scalar()
 
-            res_type = res_type or "any"
-            raise MatchboxResolutionNotFoundError(
-                message=f"No resolution {resolution_name} of {res_type}."
-            )
+        if resolution:
+            return resolution
+
+        res_type = res_type or "any"
+        raise MatchboxResolutionNotFoundError(
+            message=f"No resolution {resolution_name} of {res_type}."
+        )
 
 
 class PKSpace(MBDB.MatchboxBase):
@@ -327,13 +333,11 @@ class Sources(CountMixin, MBDB.MatchboxBase):
     columns = relationship(
         "SourceColumns",
         back_populates="source",
-        cascade="all, delete-orphan",
         passive_deletes=True,
     )
     cluster_source_pks = relationship(
         "ClusterSourcePK",
         back_populates="source",
-        cascade="all, delete-orphan",
         passive_deletes=True,
     )
     clusters = relationship(
@@ -415,13 +419,11 @@ class Clusters(CountMixin, MBDB.MatchboxBase):
     source_pks = relationship(
         "ClusterSourcePK",
         back_populates="cluster",
-        cascade="all, delete-orphan",
         passive_deletes=True,
     )
     probabilities = relationship(
         "Probabilities",
         back_populates="proposes",
-        cascade="all, delete-orphan",
         passive_deletes=True,
     )
     children = relationship(

--- a/src/matchbox/server/postgresql/utils/db.py
+++ b/src/matchbox/server/postgresql/utils/db.py
@@ -20,7 +20,6 @@ from sqlalchemy.sql import Select
 
 from matchbox.common.exceptions import (
     MatchboxDatabaseWriteError,
-    MatchboxResolutionNotFoundError,
 )
 from matchbox.common.graph import (
     ResolutionEdge,
@@ -36,27 +35,6 @@ from matchbox.server.postgresql.orm import (
 )
 
 # Retrieval
-
-
-def resolve_model_name(model: str) -> Resolutions:
-    """Resolves a model name to a Resolution object.
-
-    Args:
-        model: The name of the model to resolve.
-
-    Raises:
-        MatchboxResolutionNotFoundError: If the model doesn't exist.
-    """
-    with MBDB.get_session() as session:
-        if (
-            resolution := session.query(Resolutions)
-            .filter_by(name=model, type="model")
-            .first()
-        ):
-            return resolution
-        raise MatchboxResolutionNotFoundError(
-            message=f"Resolution {model} not found or not of type 'model'."
-        )
 
 
 def get_resolution_graph() -> ResolutionGraph:

--- a/test/client/test_model.py
+++ b/test/client/test_model.py
@@ -9,10 +9,10 @@ from matchbox.common.arrow import SCHEMA_RESULTS, table_to_buffer
 from matchbox.common.dtos import (
     BackendRetrievableType,
     BackendUploadType,
+    CRUDOperation,
     ModelAncestor,
-    ModelOperationStatus,
-    ModelOperationType,
     NotFoundError,
+    ResolutionOperationStatus,
     UploadStatus,
 )
 from matchbox.common.exceptions import (
@@ -33,10 +33,10 @@ def test_insert_model(matchbox_api: MockRouter):
     route = matchbox_api.post("/models").mock(
         return_value=Response(
             201,
-            json=ModelOperationStatus(
+            json=ResolutionOperationStatus(
                 success=True,
-                model_name=testkit.model.metadata.name,
-                operation=ModelOperationType.INSERT,
+                resolution_name=testkit.model.metadata.name,
+                operation=CRUDOperation.CREATE,
             ).model_dump(),
         )
     )
@@ -60,10 +60,10 @@ def test_insert_model_error(matchbox_api: MockRouter):
     route = matchbox_api.post("/models").mock(
         return_value=Response(
             500,
-            json=ModelOperationStatus(
+            json=ResolutionOperationStatus(
                 success=False,
-                model_name=testkit.model.metadata.name,
-                operation=ModelOperationType.INSERT,
+                resolution_name=testkit.model.metadata.name,
+                operation=CRUDOperation.CREATE,
                 details="Internal server error",
             ).model_dump(),
         )
@@ -239,10 +239,10 @@ def test_truth_setter(matchbox_api: MockRouter):
     route = matchbox_api.patch(f"/models/{testkit.model.metadata.name}/truth").mock(
         return_value=Response(
             200,
-            json=ModelOperationStatus(
+            json=ResolutionOperationStatus(
                 success=True,
-                model_name=testkit.model.metadata.name,
-                operation=ModelOperationType.UPDATE_TRUTH,
+                resolution_name=testkit.model.metadata.name,
+                operation=CRUDOperation.UPDATE,
             ).model_dump(),
         )
     )
@@ -305,10 +305,10 @@ def test_ancestors_cache_operations(matchbox_api: MockRouter):
     ).mock(
         return_value=Response(
             200,
-            json=ModelOperationStatus(
+            json=ResolutionOperationStatus(
                 success=True,
-                model_name=testkit.model.metadata.name,
-                operation=ModelOperationType.UPDATE_ANCESTOR_CACHE,
+                resolution_name=testkit.model.metadata.name,
+                operation=CRUDOperation.UPDATE,
             ).model_dump(),
         )
     )
@@ -335,21 +335,21 @@ def test_ancestors_cache_set_error(matchbox_api: MockRouter):
         testkit.model.ancestors_cache = {"model1": 1.1}
 
 
-def test_delete_model(matchbox_api: MockRouter):
-    """Test successfully deleting a model."""
+def test_delete_resolution(matchbox_api: MockRouter):
+    """Test successfully deleting a resolution."""
     # Create test model using factory
     testkit = model_factory()
 
     # Mock the DELETE endpoint with success response
     route = matchbox_api.delete(
-        f"/models/{testkit.model.metadata.name}", params={"certain": True}
+        f"/resolutions/{testkit.model.metadata.name}", params={"certain": True}
     ).mock(
         return_value=Response(
             200,
-            json=ModelOperationStatus(
+            json=ResolutionOperationStatus(
                 success=True,
-                model_name=testkit.model.metadata.name,
-                operation=ModelOperationType.DELETE,
+                resolution_name=testkit.model.metadata.name,
+                operation=CRUDOperation.DELETE,
             ).model_dump(),
         )
     )
@@ -363,20 +363,20 @@ def test_delete_model(matchbox_api: MockRouter):
     assert route.calls.last.request.url.params["certain"] == "true"
 
 
-def test_delete_model_needs_confirmation(matchbox_api: MockRouter):
-    """Test attempting to delete a model without confirmation returns 409."""
+def test_delete_resolution_needs_confirmation(matchbox_api: MockRouter):
+    """Test attempting to delete a resolution without confirmation returns 409."""
     # Create test model using factory
     testkit = model_factory()
 
     # Mock the DELETE endpoint with 409 confirmation required response
     error_details = "Cannot delete model with dependent models: dedupe1, dedupe2"
-    route = matchbox_api.delete(f"/models/{testkit.model.metadata.name}").mock(
+    route = matchbox_api.delete(f"/resolutions/{testkit.model.metadata.name}").mock(
         return_value=Response(
             409,
-            json=ModelOperationStatus(
+            json=ResolutionOperationStatus(
                 success=False,
-                model_name=testkit.model.metadata.name,
-                operation=ModelOperationType.DELETE,
+                resolution_name=testkit.model.metadata.name,
+                operation=CRUDOperation.DELETE,
                 details=error_details,
             ).model_dump(),
         )

--- a/test/server/api/routes/test_routes_main.py
+++ b/test/server/api/routes/test_routes_main.py
@@ -520,59 +520,28 @@ def test_clear_backend_errors(test_client: TestClient):
 
 
 def test_api_key_authorisation(test_client: TestClient):
+    routes = [
+        (test_client.post, "/upload/upload_id"),
+        (test_client.post, "/sources"),
+        (test_client.post, "/models"),
+        (test_client.patch, "/models/model_name/truth"),
+        (test_client.delete, "/resolutions/model_name"),
+        (test_client.delete, "/database"),
+    ]
+
     # Incorrect API Key Value
     test_client.headers["X-API-Key"] = "incorrect-api-key"
-
-    response = test_client.post("/upload/upload_id")
-    assert response.status_code == 401
-    assert response.content == b'"API Key invalid."'
-
-    response = test_client.post("/sources")
-    assert response.status_code == 401
-    assert response.content == b'"API Key invalid."'
-
-    response = test_client.post("/models")
-    assert response.status_code == 401
-    assert response.content == b'"API Key invalid."'
-
-    response = response = test_client.patch("/models/model_name/truth")
-    assert response.status_code == 401
-    assert response.content == b'"API Key invalid."'
-
-    response = test_client.delete("/models/model_name")
-    assert response.status_code == 401
-    assert response.content == b'"API Key invalid."'
-
-    response = test_client.delete("/database")
-    assert response.status_code == 401
-    assert response.content == b'"API Key invalid."'
+    for method, url in routes:
+        response = method(url)
+        assert response.status_code == 401
+        assert response.content == b'"API Key invalid."'
 
     # Missing API Key Value
     test_client.headers.pop("X-API-Key")
-
-    response = test_client.post("/upload/upload_id")
-    assert response.status_code == 403
-    assert response.content == b'"Not authenticated"'
-
-    response = test_client.post("/sources")
-    assert response.status_code == 403
-    assert response.content == b'"Not authenticated"'
-
-    response = test_client.post("/models")
-    assert response.status_code == 403
-    assert response.content == b'"Not authenticated"'
-
-    response = response = test_client.patch("/models/model_name/truth")
-    assert response.status_code == 403
-    assert response.content == b'"Not authenticated"'
-
-    response = test_client.delete("/models/model_name")
-    assert response.status_code == 403
-    assert response.content == b'"Not authenticated"'
-
-    response = test_client.delete("/database")
-    assert response.status_code == 403
-    assert response.content == b'"Not authenticated"'
+    for method, url in routes:
+        response = method(url)
+        assert response.status_code == 403
+        assert response.content == b'"Not authenticated"'
 
 
 def test_get_resolution_graph(

--- a/test/server/api/routes/test_routes_models.py
+++ b/test/server/api/routes/test_routes_models.py
@@ -517,7 +517,7 @@ def test_delete_resolution_needs_confirmation(test_client: TestClient):
     app.dependency_overrides[backend] = lambda: mock_backend
 
     testkit = model_factory()
-    response = test_client.delete(f"/models/{testkit.model.metadata.name}")
+    response = test_client.delete(f"/resolutions/{testkit.model.metadata.name}")
 
     assert response.status_code == 409
     assert response.json()["success"] is False

--- a/test/server/test_adapter.py
+++ b/test/server/test_adapter.py
@@ -209,7 +209,7 @@ class TestMatchboxBackend:
             cluster_assoc_count_post_delete = self.backend.creates.count()
             proposed_merge_probs_post_delete = self.backend.proposes.count()
 
-            # 1 source, 1 index, 1 deduper, 3 linkers are gone
+            # 1 source, 1 index, (1 deduper + 3 linkers) = 4 models are gone
             assert source_configs_post_delete == source_configs_pre_delete - 1
             assert sources_post_delete == sources_pre_delete - 1
             assert models_post_delete == models_pre_delete - 4

--- a/test/server/test_adapter.py
+++ b/test/server/test_adapter.py
@@ -192,14 +192,12 @@ class TestMatchboxBackend:
             cluster_count_pre_delete = self.backend.clusters.count()
             cluster_assoc_count_pre_delete = self.backend.creates.count()
             proposed_merge_probs_pre_delete = self.backend.proposes.count()
-            actual_merges_pre_delete = self.backend.merges.count()
 
             assert sources_pre_delete == total_sources
             assert models_pre_delete == total_models
             assert cluster_count_pre_delete > 0
             assert cluster_assoc_count_pre_delete > 0
             assert proposed_merge_probs_pre_delete > 0
-            assert actual_merges_pre_delete > 0
 
             # Perform deletion
             self.backend.delete_resolution(resolution_to_delete, certain=True)
@@ -207,20 +205,17 @@ class TestMatchboxBackend:
             source_configs_post_delete = self.backend.datasets.count()
             sources_post_delete = self.backend.source_resolutions.count()
             models_post_delete = self.backend.models.count()
-            # cluster_count_post_delete = self.backend.clusters.count()
+            cluster_count_post_delete = self.backend.clusters.count()
             cluster_assoc_count_post_delete = self.backend.creates.count()
             proposed_merge_probs_post_delete = self.backend.proposes.count()
-            # actual_merges_post_delete = self.backend.merges.count()
 
             # 1 source, 1 index, 1 deduper, 3 linkers are gone
             assert source_configs_post_delete == source_configs_pre_delete - 1
             assert sources_post_delete == sources_pre_delete - 1
             assert models_post_delete == models_pre_delete - 4
 
-            # TODO: what is going on here??
-            # Cluster, dedupe and link count unaffected
-            # assert cluster_count_post_delete == cluster_count_pre_delete
-            # assert actual_merges_post_delete == actual_merges_pre_delete
+            # We've lost some composite clusters
+            assert cluster_count_post_delete < cluster_count_pre_delete
 
             # Count of propose and create edges has dropped
             assert cluster_assoc_count_post_delete < cluster_assoc_count_pre_delete

--- a/test/server/test_adapter.py
+++ b/test/server/test_adapter.py
@@ -172,7 +172,7 @@ class TestMatchboxBackend:
             with pytest.raises(MatchboxResolutionNotFoundError):
                 self.backend.get_model(model="nonexistent")
 
-    def test_delete_model(self):
+    def test_delete_resolution(self):
         """
         Tests the deletion of:
 
@@ -202,7 +202,7 @@ class TestMatchboxBackend:
             assert actual_merges_pre_delete > 0
 
             # Perform deletion
-            self.backend.delete_model(deduper_to_delete, certain=True)
+            self.backend.delete_resolution(deduper_to_delete, certain=True)
 
             models_post_delete = self.backend.models.count()
             cluster_count_post_delete = self.backend.clusters.count()


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

* Generalised deletion of models to deletion of resolutions across client, API and adapter
* Cleaned up ORM definitions of deletion cascading behaviour

## 👀 Guidance to review

* We've lost some fidelity in the DTO operation type, i.e. whether we're updating truth or ancestors cache. My idea is that as part of [this ticket](https://uktrade.atlassian.net/jira/software/projects/MTCHBX/boards/1123?assignee=61570c67c669a60069356d3a&selectedIssue=MTCHBX-321) we'd create an update endpoint for resolution - a single one, not one for name, for description etc. And as such it won't make sense to separate different update operations. Thoughts?
* Improving the DB counts (e.g. `adapter.clusters.count()`) is tracked in [this ticket](https://uktrade.atlassian.net/browse/MTCHBX-336)


## 🤖 AI declaration

None.

## 🔗 Relevant links

* [SQLAlchemy docs on cascades](https://docs.sqlalchemy.org/en/20/orm/cascades.html)
* Inspiration for removing SQLAlchemy cascade: https://stackoverflow.com/a/38770040

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation
