### PR TITLE
Basic parquet to warehouse function

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+
+def dataset_parquet_to_local_warehouse(
+    parquetpath: Path, schema: str, table: str, dtype: Dict[str, type]
+) -> None:
+    """Load dataset parquet file to local warehouse instance.
+
+    Args:
+        parquetpath: Path to parquet file.
+        schema: Name of schema in local database.
+        table: Name of new table in local database.
+        dtype: Dictionary of dataset column names and sqlalchemy types.
+    """
+
+    user = "warehouse_user"
+    password = "warehouse_password"
+    host = "localhost"
+    database = "warehouse"
+    port = 7654
+
+    engine = create_engine(
+        f"postgresql+psycopg://{user}:{password}@{host}:{port}/{database}"
+    )
+    with engine.connect() as connection:
+        connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema}"))
+        connection.commit()
+
+    dataset = pd.read_parquet(parquetpath, dtype_backend="pyarrow")
+    dataset.to_sql(
+        name=table,
+        con=engine,
+        schema=schema,
+        if_exists="replace",
+        dtype=dtype,
+        chunksize=100000,
+        index=False,
+    )
+    engine.dispose()

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Dict
 
 import pandas as pd
 from sqlalchemy import create_engine, text
+from sqlalchemy.types import TypeEngine
 
 
 def dataset_parquet_to_local_warehouse(
-    parquetpath: Path, schema: str, table: str, dtype: Dict[str, type]
+    parquetpath: Path, schema: str, table: str, dtype: dict[str, TypeEngine]
 ) -> None:
     """Load dataset parquet file to local warehouse instance.
 


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

This commit adds a simple function for uploading parquet files of datasets to a local instance of the matchbox warehouse. 

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation
