### PR TITLE
Content hashes stable through hmrc pipeline

### DIFF
--- a/src/matchbox/client/models/dedupers/naive.py
+++ b/src/matchbox/client/models/dedupers/naive.py
@@ -52,7 +52,7 @@ class NaiveDeduper(Deduper):
         # We also need to suppress raw.left_id = raw.right_id in cases where
         # we're deduplicating an unnested array of primary keys
         sql = f"""
-            select distinct on (list_sort([raw.left_id, raw.right_id]))
+            select distinct
                 raw.left_id,
                 raw.right_id,
                 1.0 as probability

--- a/src/matchbox/common/exceptions.py
+++ b/src/matchbox/common/exceptions.py
@@ -195,10 +195,6 @@ class MatchboxDeletionNotConfirmed(Exception):
         super().__init__(message)
 
 
-class MatchboxResolutionAlreadyExists(Exception):
-    """Resolution already exists."""
-
-
 # -- Adapter DB exceptions --
 
 

--- a/src/matchbox/server/postgresql/utils/insert.py
+++ b/src/matchbox/server/postgresql/utils/insert.py
@@ -8,7 +8,6 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from matchbox.common.db import sql_to_df
 from matchbox.common.dtos import ModelResolutionName
-from matchbox.common.exceptions import MatchboxResolutionAlreadyExists
 from matchbox.common.graph import ResolutionNodeType
 from matchbox.common.hash import hash_arrow_table, hash_values
 from matchbox.common.logging import logger
@@ -296,7 +295,6 @@ def insert_model(
 
     Raises:
         MatchboxResolutionNotFoundError: If the specified parent models don't exist.
-        MatchboxResolutionAlreadyExists: If the specified model already exists.
     """
     log_prefix = f"Model {name}"
     logger.info("Registering", prefix=log_prefix)
@@ -306,7 +304,8 @@ def insert_model(
         exists_obj = session.scalar(exists_stmt)
 
         if exists_obj is not None:
-            raise MatchboxResolutionAlreadyExists
+            logger.info("Model resolution already exists", prefix=log_prefix)
+            return
         else:
             new_res = Resolutions(
                 type=ResolutionNodeType.MODEL.value,

--- a/test/server/test_adapter.py
+++ b/test/server/test_adapter.py
@@ -9,7 +9,6 @@ from matchbox.common.arrow import SCHEMA_MB_IDS
 from matchbox.common.dtos import ModelAncestor, ModelConfig, ModelType
 from matchbox.common.exceptions import (
     MatchboxDataNotFound,
-    MatchboxResolutionAlreadyExists,
     MatchboxResolutionNotFoundError,
     MatchboxSourceNotFoundError,
 )
@@ -261,20 +260,6 @@ class TestMatchboxBackend:
                     right_resolution="dedupe_2",
                 )
             )
-
-            assert self.backend.models.count() == models_count + 3
-
-            # Test can't insert duplicate
-            with pytest.raises(MatchboxResolutionAlreadyExists):
-                self.backend.insert_model(
-                    model_config=ModelConfig(
-                        name="link_1",
-                        description="Test upsert",
-                        type=ModelType.LINKER,
-                        left_resolution="dedupe_1",
-                        right_resolution="dedupe_2",
-                    )
-                )
 
             assert self.backend.models.count() == models_count + 3
 


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

This PR haas been tested by running pipelines in a local environment and checking that content hash comparison points were reached for each node.
 - Remove resolution matching error. 
 - Update naive dedupe to remove list_sort. This introduced a random resorts in the left_id, right_id order of certain nodes that meant the content hash was different on reruns.  

## 👀 Guidance to review

<!-- Help reviewers know where to focus their efforts, or flag controversial decisions -->

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation
