### PR TITLE
Disable temporarily patching of parallel executor

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          uv run pytest
+          uv run pytest -v
 
       - name: Dump docker logs
         if: failure()

--- a/test/common/test_transform.py
+++ b/test/common/test_transform.py
@@ -295,6 +295,7 @@ def test_hierarchical_clusters(input_data, expected_hierarchy):
         dtype=pa.string,
         proc_func=component_to_hierarchy,
         hash_func=_combine_strings,
+        timeout=5,
     )
 
     result = result.sort_by(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -47,14 +47,14 @@ def parallel_pool_for_tests(
             executor.shutdown(wait=False, cancel_futures=True)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def patch_multiprocessing() -> Iterator[None]:
-    """Patch ProcessPoolExecutor to use ThreadPoolExecutor in tests."""
-    with patch(
-        "matchbox.common.transform.ProcessPoolExecutor",
-        lambda *args, **kwargs: parallel_pool_for_tests(timeout=30),
-    ):
-        yield
+# @pytest.fixture(scope="session", autouse=True)
+# def patch_multiprocessing() -> Iterator[None]:
+#     """Patch ProcessPoolExecutor to use ThreadPoolExecutor in tests."""
+#     with patch(
+#         "matchbox.common.transform.ProcessPoolExecutor",
+#         lambda *args, **kwargs: parallel_pool_for_tests(timeout=30),
+#     ):
+#         yield
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,5 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 from unittest.mock import patch
@@ -30,31 +29,11 @@ def test_root_dir() -> Path:
     return TEST_ROOT
 
 
-@contextmanager
-def parallel_pool_for_tests(
-    max_workers: int = 2, timeout: int = 30
-) -> Iterator[ThreadPoolExecutor]:
-    """Context manager for safe parallel execution in tests using threads.
-
-    Args:
-        max_workers: Maximum number of worker threads
-        timeout: Maximum seconds to wait for each task
-    """
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        try:
-            yield executor
-        finally:
-            executor.shutdown(wait=False, cancel_futures=True)
-
-
-# @pytest.fixture(scope="session", autouse=True)
-# def patch_multiprocessing() -> Iterator[None]:
-#     """Patch ProcessPoolExecutor to use ThreadPoolExecutor in tests."""
-#     with patch(
-#         "matchbox.common.transform.ProcessPoolExecutor",
-#         lambda *args, **kwargs: parallel_pool_for_tests(timeout=30),
-#     ):
-#         yield
+@pytest.fixture(scope="session", autouse=True)
+def patch_multiprocessing() -> Iterator[None]:
+    """Patch ProcessPoolExecutor to use ThreadPoolExecutor in tests."""
+    with patch("matchbox.common.transform.ProcessPoolExecutor", ThreadPoolExecutor):
+        yield
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

* Simplified patching of process pool executor for tests

## 👀 Guidance to review
I've run tests successfully 5 times.
I'm not actually sure why this works and whether or not it addresses the hanging problem. I don't see how it should, as I haven't changed anything substantial but things seem to be working now.

## 🤖 AI declaration

I just used it to talk through the difference between threads and processes in terms of execution.

## 🔗 Relevant links

* From the [Python docs](https://docs.python.org/3/library/concurrent.futures.html), it seems that calling shutdown is not required if using with the context manager. This will have by default `wait=True`, but as far as I understand, that would nor have been called anyway.

## ✅ Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've changed or updated relevant documentation
