### PR TITLE
Improve way SourceConfig use connections

### DIFF
--- a/docs/client/link-data.md
+++ b/docs/client/link-data.md
@@ -56,7 +56,7 @@ The `key_field` is the field in your source that contains some unique code that 
     from matchbox.common.sources import SourceConfig, RelationalDBLocation
     
     # Companies House data
-    companies_house = SourceConfig(
+    companies_house = SourceConfig.new(
         location=RelationalDBLocation.from_engine(engine),
         extract_transform="""
             select
@@ -67,16 +67,12 @@ The `key_field` is the field in your source that contains some unique code that 
             from
                 companieshouse.companies;
         """,
-        index_fields=[
-            {"name": "company_name", "type": "String"},
-            {"name": "company_number", "type": "String"},
-            {"name": "postcode", "type": "String"},
-        ],
-        key_field={"name": "id", "type": "String"},
-    ).set_engine(engine)
+        index_fields=["company_name", "company_number", "postcode"],
+        key_field="id",
+    )
     
     # Exporters data
-    exporters = SourceConfig(
+    exporters = SourceConfig.new(
         location=RelationalDBLocation.from_engine(engine),
         extract_transform="""
             select
@@ -86,12 +82,9 @@ The `key_field` is the field in your source that contains some unique code that 
             from
                 hmrc.trade__exporters;
         """,
-        index_fields=[
-            {"name": "company_name", "type": "String"},
-            {"name": "postcode", "type": "String"},
-        ],
-        key_field={"name": "id", "type": "String"},
-    ).set_engine(engine)
+        index_fields=["company_name", "postcode"],
+        key_field="id",
+    )
     ```
 
 Each [`SourceConfig`][matchbox.common.sources.SourceConfig] object requires:

--- a/src/matchbox/client/dags.py
+++ b/src/matchbox/client/dags.py
@@ -138,7 +138,6 @@ class ModelStep(Step):
             resolution=step_input.name,
             only_indexed=True,
             batch_size=step_input.batch_size,
-            return_batches=False,
         )
 
 

--- a/src/matchbox/client/dags.py
+++ b/src/matchbox/client/dags.py
@@ -82,7 +82,8 @@ class IndexStep(Step):
     batch_size: int | None = Field(default=None)
 
     @model_validator(mode="before")
-    def source_to_atrtibutes(cls, data: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def source_to_attributes(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Convert source config to name and sources attributes."""
         if "source_config" not in data:
             raise ValueError("SourceConfig must be provided")

--- a/src/matchbox/client/helpers/selector.py
+++ b/src/matchbox/client/helpers/selector.py
@@ -77,7 +77,7 @@ class Selector(BaseModel):
         else:
             selected_fields = list(source.index_fields)  # Must actively select key
 
-        source.set_credentials(credentials=credentials)
+        source.location.add_credentials(credentials=credentials)
         return cls(source=source, fields=selected_fields)
 
 

--- a/src/matchbox/common/db.py
+++ b/src/matchbox/common/db.py
@@ -98,11 +98,21 @@ def sql_to_df(
         If return_batches is True: An iterator of dataframes in the specified format.
 
     Raises:
-        ValueError: If the connection is not properly configured or if an unsupported
-            return type is specified.
+        ValueError:
+
+            * If the connection is not properly configured or if an unsupported
+                return type is specified.
+            * If batch_size and return_batches are either both set or both unset.
+
     """
     if return_type not in get_args(ReturnTypeStr):
         raise ValueError(f"return_type of {return_type} not valid")
+
+    if not batch_size and return_batches:
+        raise ValueError("A batch size must be specified if return_batches is True")
+
+    if batch_size and not return_batches:
+        raise ValueError("Cannot set a batch size if return_batches if False")
 
     def _to_format(results: PolarsDataFrame) -> QueryReturnType:
         """Convert the results to the specified format."""
@@ -124,9 +134,6 @@ def sql_to_df(
         schema_overrides=schema_overrides,
         execute_options=execute_options,
     )
-
-    if not bool(batch_size):
-        return _to_format(res)
 
     if not return_batches:
         return _to_format(pl.concat(res))

--- a/src/matchbox/common/db.py
+++ b/src/matchbox/common/db.py
@@ -135,10 +135,10 @@ def sql_to_df(
         execute_options=execute_options,
     )
 
-    if not return_batches:
-        return _to_format(pl.concat(res))
+    if return_batches:
+        return (_to_format(batch) for batch in res)
 
-    return (_to_format(batch) for batch in res)
+    return _to_format(res)
 
 
 def validate_sql_for_data_extraction(sql: str) -> bool:

--- a/src/matchbox/common/factories/sources.py
+++ b/src/matchbox/common/factories/sources.py
@@ -111,7 +111,6 @@ class SourceTestkit(BaseModel):
         """Create a mock SourceConfig object with this testkit's configuration."""
         mock_source_config = create_autospec(self.source_config)
 
-        mock_source_config.set_credentials.return_value = mock_source_config
         mock_source_config.hash_data.return_value = self.data_hashes
 
         mock_source_config.model_dump.side_effect = self.source_config.model_dump
@@ -133,10 +132,6 @@ class SourceTestkit(BaseModel):
             [self.data["id"], self.data["key"]], names=["id", "key"]
         )
 
-    def set_credentials(self, credentials: Any) -> None:
-        """Set the credentials for the SourceConfig."""
-        self.source_config.set_credentials(credentials)
-
     def write_to_location(
         self, credentials: Any, set_credentials: bool = False
     ) -> None:
@@ -155,7 +150,7 @@ class SourceTestkit(BaseModel):
             if_table_exists="replace",
         )
         if set_credentials:
-            self.set_credentials(credentials)
+            self.source_config.location.add_credentials(credentials)
 
 
 class LinkedSourcesTestkit(BaseModel):

--- a/src/matchbox/common/factories/sources.py
+++ b/src/matchbox/common/factories/sources.py
@@ -112,7 +112,6 @@ class SourceTestkit(BaseModel):
         mock_source_config = create_autospec(self.source_config)
 
         mock_source_config.hash_data.return_value = self.data_hashes
-
         mock_source_config.model_dump.side_effect = self.source_config.model_dump
         mock_source_config.model_dump_json.side_effect = (
             self.source_config.model_dump_json

--- a/src/matchbox/common/factories/sources.py
+++ b/src/matchbox/common/factories/sources.py
@@ -112,7 +112,6 @@ class SourceTestkit(BaseModel):
         mock_source_config = create_autospec(self.source_config)
 
         mock_source_config.set_credentials.return_value = mock_source_config
-        mock_source_config.from_location.return_value = mock_source_config
         mock_source_config.hash_data.return_value = self.data_hashes
 
         mock_source_config.model_dump.side_effect = self.source_config.model_dump

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -404,7 +404,12 @@ class SourceConfig(BaseModel):
             for col in sample.iter_columns()
         }
 
-        typed_key_field = remote_fields[key_field]
+        if remote_fields[key_field].type != DataTypes.STRING:
+            raise ValueError(
+                "The keys read from the extract transform logic must be strings."
+            )
+
+        typed_key_field = SourceField(name=key_field, type=DataTypes.STRING)
         typed_index_fields = tuple(remote_fields[field] for field in index_fields)
 
         return cls(

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -426,15 +426,6 @@ class SourceConfig(BaseModel):
 
         return self
 
-    def set_credentials(self, credentials: Any) -> None:
-        """Set the credentials for the location.
-
-        Args:
-            credentials: The credentials to set.
-        """
-        self.location.add_credentials(credentials)
-        self.validate_location_et_fields()
-
     def query(
         self,
         qualify_names: bool = False,

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -406,7 +406,8 @@ class SourceConfig(BaseModel):
 
         if remote_fields[key_field].type != DataTypes.STRING:
             raise ValueError(
-                "The keys read from the extract transform logic must be strings."
+                f"Your key_field, {key_field}, must coerce to a string "
+                "in the extract transform logic. "
             )
 
         typed_key_field = SourceField(name=key_field, type=DataTypes.STRING)

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -232,7 +232,7 @@ class RelationalDBLocation(Location):
         rename: dict[str, str] | Callable | None = None,
         return_type: ReturnTypeStr = "polars",
     ) -> Generator[QueryReturnType, None, None]:
-        batch_size = 10_000 or batch_size
+        batch_size = batch_size or 10_000
         with self.credentials.connect() as conn:
             yield from sql_to_df(
                 stmt=extract_transform,

--- a/test/client/test_dags.py
+++ b/test/client/test_dags.py
@@ -163,7 +163,6 @@ def test_dedupe_step_run(
             resolution=d_foo.left.name,
             only_indexed=True,
             batch_size=100 if batched else None,
-            return_batches=False,
         )
         # Data is pre-processed
         process_mock.assert_called_once_with(
@@ -255,7 +254,6 @@ def test_link_step_run(
             resolution=foo_bar.left.name,
             only_indexed=True,
             batch_size=100 if batched else None,
-            return_batches=False,
         )
         assert query_mock.call_args_list[1] == call(
             [Selector(source=bar, fields=[])],
@@ -264,7 +262,6 @@ def test_link_step_run(
             resolution=foo_bar.right.name,
             only_indexed=True,
             batch_size=100 if batched else None,
-            return_batches=False,
         )
 
         # Data is pre-processed

--- a/test/common/factories/test_source_factory.py
+++ b/test/common/factories/test_source_factory.py
@@ -145,19 +145,13 @@ def test_source_testkit_to_mock():
 
     # Test that method calls are tracked
     mock_source.set_credentials(credentials="test_engine")
-    mock_source.from_location(location="test_location", extract_transform="test_et")
     mock_source.hash_data()
 
     mock_source.set_credentials.assert_called_once_with("test_engine")
-    mock_source.from_location.assert_called_once_with("test_location", "test_et")
     mock_source.hash_data.assert_called_once()
 
     # Test method return values
     assert mock_source.set_credentials(credentials="test_engine") == mock_source
-    assert (
-        mock_source.from_location(location="test_location", extract_transform="test_et")
-        == mock_source
-    )
     assert mock_source.hash_data() == source_testkit.data_hashes
 
     # Test model dump methods

--- a/test/common/factories/test_source_factory.py
+++ b/test/common/factories/test_source_factory.py
@@ -144,14 +144,11 @@ def test_source_testkit_to_mock():
     mock_source = source_testkit.mock
 
     # Test that method calls are tracked
-    mock_source.set_credentials(credentials="test_engine")
     mock_source.hash_data()
 
-    mock_source.set_credentials.assert_called_once_with("test_engine")
     mock_source.hash_data.assert_called_once()
 
     # Test method return values
-    assert mock_source.set_credentials(credentials="test_engine") == mock_source
     assert mock_source.hash_data() == source_testkit.data_hashes
 
     # Test model dump methods

--- a/test/common/test_sources.py
+++ b/test/common/test_sources.py
@@ -392,7 +392,7 @@ def test_source_set_credentials(sqlite_warehouse: Engine):
     assert source_testkit.source_config.location.credentials is None
 
     # Set credentials through the source
-    source_testkit.source_config.set_credentials(sqlite_warehouse)
+    source_testkit.source_config.location.add_credentials(sqlite_warehouse)
 
     # Verify credentials are set on the location
     assert source_testkit.source_config.location.credentials == sqlite_warehouse

--- a/test/common/test_sources.py
+++ b/test/common/test_sources.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import polars as pl
 import pyarrow as pa
@@ -456,7 +456,7 @@ def test_source_query_name_qualification(
 ):
     """Test that column names are qualified when requested."""
     # Mock the location execute method to verify parameters
-    mock_execute.return_value = MagicMock()
+    mock_execute.return_value = (x for x in [None])  # execute needs to be a generator
     location = RelationalDBLocation(uri=str(sqlite_warehouse.url))
 
     # Create source
@@ -469,7 +469,7 @@ def test_source_query_name_qualification(
     )
 
     # Call query with qualification parameter
-    source.query(qualify_names=qualify_names)
+    next(source.query(qualify_names=qualify_names))
 
     # Verify the rename parameter passed to execute
     _, kwargs = mock_execute.call_args
@@ -505,7 +505,7 @@ def test_source_query_batching(
 ):
     """Test query with batching options."""
     # Mock the location execute method to verify parameters
-    mock_execute.return_value = MagicMock()
+    mock_execute.return_value = (x for x in [None])  # execute needs to be a generator
     location = RelationalDBLocation(uri=str(sqlite_warehouse.url))
 
     # Create source
@@ -518,7 +518,7 @@ def test_source_query_batching(
     )
 
     # Call query with batching parameters
-    source.query(batch_size=batch_size)
+    next(source.query(batch_size=batch_size))
 
     # Verify parameters passed to execute
     _, kwargs = mock_execute.call_args
@@ -592,7 +592,7 @@ def test_source_hash_data_null_identifier(mock_query: Mock, sqlite_warehouse: En
 
     # Mock query to return data with null keys
     mock_df = pl.DataFrame({"key": ["1", None], "name": ["a", "b"]})
-    mock_query.return_value = mock_df
+    mock_query.return_value = (x for x in [mock_df])
 
     # hash_data should raise ValueErrors for null keys
     with pytest.raises(ValueError, match="keys column contains null values"):


### PR DESCRIPTION
This PR stems from two problems:

* Too many requests are made to a location, caused by an after model validator that is called when a source config is initialised or attached to any other object
* Many requests cause too many connections to be opened at the same time, which causes an error

## 🛠️ Changes proposed in this pull request

* Created a single, unambiguous way of setting credentials: once, at the location level
* Created a new factory method for source configs, which infers field types
* Removed the previous factory method for source configs, which wasn't used anywhere
* Improved query which infers field types from location
* Removed non-generator version of `Location.execute()` and `Source.query()`
* Removed generator version of `Source.hash_data()` and the `query()` helper

## 👀 Guidance to review
### Why were we running out of connections?
Because:

* We were making lazy calls to the DB that were only consuming some of the data and then weren't returning the connection to the pool
* By passing the engine to polars instead of a connection, the pool max connection parameter was not being enforced (I think - I still don't understand why this would be the case but empirically it seems so)

The new approach ensures that once the output of locations' execute is fully consumed, or the variable to which the generator is assigned goes out of scope, the connection is returned to the engine's pool. This pattern is a good fit in our situation where e.g. `SourceConfig.query()` consumes the generator but only `Location.execute()` can manage the lifecycle of the SQLAlchemy connections - so `Location.execute()` needs to implement a mechanism to release the connection without consuming the whole generator, and `SourceConfig.query()` needs to consume the generator however it pleases but can't close the connection once it's done.

### Why the new SourceConfig factory?
We had previously discussed an alternative solution. This has a few advantages:

* It means that if users set location as we currently do in our own pipelines, i.e. once, at the location level, they don't miss out on validation. Instead, what guarantees the safety of the field definitions is that we have two distinct ways of creating `SourceConfig`: through the constructor, only used for loading the DTO from the backend or for tests, or using the `new()` factory, to create a DAG
* The `new()` factory has the added convenience of simplifying the definition of a source config on the client side. It assumes that credentials have been set (or it will error); and allows to get rid of the validator and only connect to the location once upon creation of the config. So it's overall safer, and it makes sense that a source config would be checked against the location only if it's "new" - and it always needs to be checked

## 🤖 AI declaration
Used to reason about:

* when model validators were being called
* idea of using yield from

## 🔗 Relevant links
None

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] I've changed or updated relevant documentation
