### PR TITLE
Allow upper-case characters for source configs

### DIFF
--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -361,7 +361,7 @@ class SourceConfig(BaseModel):
         Raises:
             ValueError: If the name is not a valid source resolution name.
         """
-        if not re.match(r"^[a-z0-9_]+$", value):
+        if not re.match(r"^[a-zA-Z0-9_]+$", value):
             raise ValueError(
                 "Source resolution names must be alphanumeric and underscore only. "
             )


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

* Allow source config to have upper case characters in their names

## 👀 Guidance to review
None

## 🤖 AI declaration
None

## 🔗 Relevant links

None

## ✅ Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've changed or updated relevant documentation
