### PR TITLE
Added SplinkLinker to e2e DAG tests

### DIFF
--- a/src/matchbox/client/clean/__init__.py
+++ b/src/matchbox/client/clean/__init__.py
@@ -9,8 +9,13 @@ from matchbox.client.clean.lib import (
     extract_duns_number_to_new,
     postcode,
     postcode_to_area,
+    remove_prefix,
 )
-from matchbox.client.clean.utils import alias, cleaning_function, unnest_renest
+from matchbox.client.clean.utils import (
+    alias,
+    cleaning_function,
+    unnest_renest,
+)
 
 __all__ = (
     # Cleaning functions
@@ -26,4 +31,5 @@ __all__ = (
     "alias",
     "cleaning_function",
     "unnest_renest",
+    "remove_prefix",
 )

--- a/src/matchbox/client/clean/lib.py
+++ b/src/matchbox/client/clean/lib.py
@@ -189,3 +189,31 @@ def drop(df: DataFrame, column: str) -> DataFrame:
         dataframe: the same as went in without the column
     """
     return df.drop(columns=[column])
+
+
+def remove_prefix(df: DataFrame, column: str, prefix: str) -> DataFrame:
+    """Remove a prefix from any column names that contain it.
+
+    Args:
+        df: a dataframe
+        column: a dead variable to appease Matchbox while a bug is fixed
+        prefix: the prefix string to remove from column names
+
+    Returns:
+        dataframe: the same as went in, but with column names cleaned
+    """
+    del column
+
+    # Create a mapping of old column names to new column names
+    column_mapping = {}
+
+    for col in df.columns:
+        if col.startswith(prefix):
+            new_col = col[len(prefix) :]
+            column_mapping[col] = new_col
+
+    # Rename columns if any matches were found
+    if column_mapping:
+        df = df.rename(columns=column_mapping)
+
+    return df

--- a/src/matchbox/client/clean/utils.py
+++ b/src/matchbox/client/clean/utils.py
@@ -1,9 +1,11 @@
 """Generic utilities for default cleaning functions."""
 
-from typing import Callable
+from typing import Any, Callable
 
 import duckdb
 from pandas import ArrowDtype, DataFrame
+
+from matchbox.client.helpers.cleaner import cleaners
 
 STOPWORDS = [
     "limited",
@@ -156,3 +158,62 @@ def unnest_renest(function: Callable) -> Callable:
         return renest
 
     return cleaning_method
+
+
+def select_cleaners(*sources: tuple[dict, list[str]]) -> dict[str, dict[str, Any]]:
+    """Select cleaners from one or more (cleaner_dict, keys) pairs.
+
+    Useful for storing a dictionary of cleaning funtions for a particular source,
+    then building them dynamically based on the keys you want to use.
+
+    Examples:
+        ```python
+        from matchbox.client import clean
+        from matchbox.client.dags import DAG, DedupeStep, IndexStep, LinkStep, StepInput
+        from matchbox.client.helpers.cleaner import cleaner, cleaners
+
+        foo_cleaners = {
+            "company_name": cleaner(
+                clean.company_name,
+                {"column": foo.qualify_field("company_name")},
+            ),
+            "company_number": cleaner(
+                clean.company_number,
+                {"column": foo.qualify_field("company_number")},
+            ),
+        }
+
+        bar_cleaners = {
+            "company_name": cleaner(
+                clean.company_name,
+                {"column": bar.qualify_field("company_name")},
+            ),
+            "postcode": cleaner(
+                clean.postcode,
+                {"column": bar.qualify_field("postcode")},
+            ),
+        }
+
+        my_linker = LinkStep(
+            left=StepInput(
+                select={
+                    foo: ["company_name"],
+                    bar: ["postcode"],
+                },
+                cleaners=select_cleaners(
+                    (foo_cleaners, ["company_name"]),
+                    (bar_cleaners, ["postcode"]),
+                ),
+                ...
+            ),
+            ...
+        )
+        ```
+
+    Returns:
+        Dictionary matching the return type of `cleaners()`
+    """
+    selected = {}
+    for cleaner_dict, keys in sources:
+        selected.update({k: v for k, v in cleaner_dict.items() if k in keys})
+    return cleaners(*selected.values())


### PR DESCRIPTION
In the hope of flushing out [Contains insert not detecting existing keys](https://uktrade.atlassian.net/browse/MTCHBX-398?atlOrigin=eyJpIjoiNDIzODFhZTdlNjdmNGFkYmI5NTFmNDE0MzgwMzQxZGQiLCJwIjoiaiJ9), I added a parallel `SplinkLinker` to the e2e tests. This was supposed to draw out a bug I thought the linker had with uploading data. This PR shows it's not an innate problem with the linker type.

Whilst this doesn't solve the problem, it adds coverage, and rules out one cause.

## 🛠️ Changes proposed in this pull request

* Adds a `SplinkLinker` to the e2e tests and shows parallel DAGs in action
* Adds `remove_prefix` cleaning function to help make data conformant for Splink
* Adds `select_cleaners` helper function to dynamically assemble cleaners from a selection built to match a particular source

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## 🔗 Relevant links

* [Contains insert not detecting existing keys](https://uktrade.atlassian.net/browse/MTCHBX-398?atlOrigin=eyJpIjoiNDIzODFhZTdlNjdmNGFkYmI5NTFmNDE0MzgwMzQxZGQiLCJwIjoiaiJ9)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [x] Tutorials
    - [x] Developer docs
