### PR TITLE
Move sampling functionality to location method

### DIFF
--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -226,9 +226,7 @@ class RelationalDBLocation(Location):
         return validate_sql_for_data_extraction(extract_transform)
 
     def head(self, extract_transform: str) -> pl.DataFrame:  # noqa: D102
-        return next(
-            self.execute(extract_transform.rstrip().rstrip(";") + " limit 100;")
-        )
+        return next(self.execute(extract_transform.rstrip(" \t\n;") + " limit 100;"))
 
     @requires_credentials
     def execute(  # noqa: D102

--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -131,6 +131,11 @@ class Location(ABC, BaseModel):
         ...
 
     @abstractmethod
+    def sample(self, extract_transform: str) -> list:
+        """Extract lightweight data sample using ET logic."""
+        ...
+
+    @abstractmethod
     def execute(
         self,
         extract_transform: str,
@@ -219,6 +224,9 @@ class RelationalDBLocation(Location):
         # Users should only run indexing using SourceConfigs they trust and have read,
         # using least privilege credentials
         return validate_sql_for_data_extraction(extract_transform)
+
+    def sample(self, extract_transform: str) -> pl.DataFrame:  # noqa: D102
+        return next(self.execute(extract_transform, batch_size=1))
 
     @requires_credentials
     def execute(  # noqa: D102
@@ -394,7 +402,7 @@ class SourceConfig(BaseModel):
     ) -> "SourceConfig":
         """Create a new SourceConfig for an indexing operation."""
         # Assumes credentials have been set on location
-        sample: pl.DataFrame = next(location.execute(extract_transform, batch_size=1))
+        sample: pl.DataFrame = location.sample(extract_transform)
 
         remote_fields = {
             col.name: SourceField(name=col.name, type=DataTypes.from_dtype(col.dtype))

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1356,6 +1355,7 @@ wheels = [
 
 [[package]]
 name = "matchbox-db"
+version = "0.3.9.dev1+g9e022650.d20250618"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1444,7 +1444,6 @@ requires-dist = [
     { name = "sqlglot", extras = ["rs"], specifier = ">=26.12.1" },
     { name = "tomli", marker = "extra == 'server'", specifier = ">=2.0.1" },
 ]
-provides-extras = ["server"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

* Added an abstract sample method to location
* Updated sampling to use original logic from new with yield batch size one. 

## 👀 Guidance to review

Is there anywhere else we can benefit from applying this method. 

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
