### PR TITLE
Fix hashing of results so model caching works again

### DIFF
--- a/src/matchbox/common/hash.py
+++ b/src/matchbox/common/hash.py
@@ -170,6 +170,10 @@ def hash_arrow_table(
             column and drop the original columns to ensure (1,2) and (2,1)
             hash to the same value. Works with 2 or more columns.
 
+            Note: if list columns are combined with a column that's nullable,
+            list + null value returns null. See Polars' concat_list documentation
+            for more details.
+
     Returns:
         Bytes representing the content hash of the table
     """

--- a/src/matchbox/common/hash.py
+++ b/src/matchbox/common/hash.py
@@ -156,6 +156,7 @@ def hash_rows(
 def hash_arrow_table(
     table: pa.Table,
     method: HashMethod = HashMethod.XXH3_128,
+    normalise: list[str] | None = None,
 ) -> bytes:
     """Computes a content hash of an Arrow table invariant to row and field order.
 
@@ -164,6 +165,10 @@ def hash_arrow_table(
     Args:
         table: The pyarrow Table to hash
         method: The method to use for hashing rows (XXH3_128 or SHA256)
+        normalise: Optional list of column names to normalise into sorted groups.
+            For example, ["left_id", "right_id"] will create a "normalised"
+            column and drop the original columns to ensure (1,2) and (2,1)
+            hash to the same value. Works with 2 or more columns.
 
     Returns:
         Bytes representing the content hash of the table
@@ -172,6 +177,21 @@ def hash_arrow_table(
 
     if df.height == 0:
         return b"empty_table_hash"
+
+    # Apply normalisation if specified
+    if normalise:
+        if len(normalise) < 2:
+            raise ValueError("normalise must contain at least 2 column names")
+
+        # Check that all columns exist
+        missing_cols = [col for col in normalise if col not in df.columns]
+        if missing_cols:
+            raise ValueError(f"Columns not found in dataframe: {missing_cols}")
+
+        # Create normalised group and drop original columns
+        df = df.with_columns(
+            pl.concat_list(normalise).list.sort().alias("normalised")
+        ).drop(normalise)
 
     columns: list[str] = sorted(df.columns)
     df = df.select(columns)
@@ -182,9 +202,7 @@ def hash_arrow_table(
             df = df.explode(column)
 
     df = df.sort(by=columns)
-
     row_hashes = hash_rows(df=df, columns=columns, method=method)
-
     all_hashes: bytes = b"".join(row_hashes.sort().to_list())
 
     return HASH_FUNC(all_hashes).digest()

--- a/src/matchbox/common/hash.py
+++ b/src/matchbox/common/hash.py
@@ -156,7 +156,7 @@ def hash_rows(
 def hash_arrow_table(
     table: pa.Table,
     method: HashMethod = HashMethod.XXH3_128,
-    normalise: list[str] | None = None,
+    as_sorted_list: list[str] | None = None,
 ) -> bytes:
     """Computes a content hash of an Arrow table invariant to row and field order.
 
@@ -165,8 +165,8 @@ def hash_arrow_table(
     Args:
         table: The pyarrow Table to hash
         method: The method to use for hashing rows (XXH3_128 or SHA256)
-        normalise: Optional list of column names to normalise into sorted groups.
-            For example, ["left_id", "right_id"] will create a "normalised"
+        as_sorted_list: Optional list of column names to hash as a sorted list.
+            For example, ["left_id", "right_id"] will create a "sorted_list"
             column and drop the original columns to ensure (1,2) and (2,1)
             hash to the same value. Works with 2 or more columns.
 
@@ -179,19 +179,21 @@ def hash_arrow_table(
         return b"empty_table_hash"
 
     # Apply normalisation if specified
-    if normalise:
-        if len(normalise) < 2:
-            raise ValueError("normalise must contain at least 2 column names")
+    if as_sorted_list:
+        if len(as_sorted_list) < 2:
+            raise ValueError(
+                "Lists passed to as_sorted_list must contain at least 2 column names"
+            )
 
         # Check that all columns exist
-        missing_cols = [col for col in normalise if col not in df.columns]
+        missing_cols = [col for col in as_sorted_list if col not in df.columns]
         if missing_cols:
             raise ValueError(f"Columns not found in dataframe: {missing_cols}")
 
         # Create normalised group and drop original columns
         df = df.with_columns(
-            pl.concat_list(normalise).list.sort().alias("normalised")
-        ).drop(normalise)
+            pl.concat_list(as_sorted_list).list.sort().alias("sorted_list")
+        ).drop(as_sorted_list)
 
     columns: list[str] = sorted(df.columns)
     df = df.select(columns)

--- a/src/matchbox/server/postgresql/utils/insert.py
+++ b/src/matchbox/server/postgresql/utils/insert.py
@@ -529,7 +529,7 @@ def insert_results(
     )
 
     # Check if the content hash is the same
-    content_hash = hash_arrow_table(results)
+    content_hash = hash_arrow_table(results, normalise=["left_id", "right_id"])
     if resolution.hash == content_hash:
         logger.info("Results already uploaded. Finished", prefix=log_prefix)
         return

--- a/src/matchbox/server/postgresql/utils/insert.py
+++ b/src/matchbox/server/postgresql/utils/insert.py
@@ -529,7 +529,7 @@ def insert_results(
     )
 
     # Check if the content hash is the same
-    content_hash = hash_arrow_table(results, normalise=["left_id", "right_id"])
+    content_hash = hash_arrow_table(results, as_sorted_list=["left_id", "right_id"])
     if resolution.hash == content_hash:
         logger.info("Results already uploaded. Finished", prefix=log_prefix)
         return

--- a/test/common/test_hash.py
+++ b/test/common/test_hash.py
@@ -80,180 +80,376 @@ def test_hash_rows(method: HashMethod):
 
 
 @pytest.mark.parametrize(
-    ["method"],
+    "method",
     [
         pytest.param(HashMethod.SHA256, id="sha256"),
         pytest.param(HashMethod.XXH3_128, id="xxh3_128"),
     ],
 )
-def test_hash_arrow_table(method: HashMethod):
-    a = pa.Table.from_pydict(
-        {
-            "a": [1, 2, 3],
-            "b": [4, 5, 6],
-        }
-    )
-    # Field order should not matter
-    b = pa.Table.from_pydict(
-        {
-            "b": [4, 5, 6],
-            "a": [1, 2, 3],
-        }
-    )
-    # Row order should not matter
-    c = pa.Table.from_pydict(
-        {
-            "a": [3, 2, 1],
-            "b": [6, 5, 4],
-        }
-    )
-    # Field and row order should not matter
-    d = pa.Table.from_pydict(
-        {
-            "b": [6, 5, 4],
-            "a": [3, 2, 1],
-        }
-    )
-    # Empty table should have a different hash
-    e = pa.Table.from_pydict(
-        {
-            "a": [],
-            "b": [],
-        }
-    )
-    # Different row data should have a different hash
-    f = pa.Table.from_pydict(
-        {
-            "a": [1, 2, 3],
-            "b": [4, 5, 7],
-        }
-    )
-    # If field name change their order, the hash should change
-    g = pa.Table.from_pydict(
-        {
-            "b": [1, 2, 3],
-            "a": [4, 5, 6],
-        }
-    )
-    # List fields are handled
-    h = pa.Table.from_pydict(
-        {
-            "a": [1, 2, 3],
-            "b": [[1, 2], [3, 4], [5, 6]],
-        }
-    )
-    # List order doesn't matter
-    i = pa.Table.from_pydict(
-        {
-            "a": [1, 2, 3],
-            "b": [[2, 1], [4, 3], [6, 5]],
-        }
-    )
-    # Binary fields are handled, including non-UTF-8 bytes
-    j = pa.Table.from_pydict(
-        {
-            "a": [1, 2, 3],
-            "b": [b"abc", None, bytes([255, 254, 253])],
-        }
-    )
+class TestArrowTableHashing:
+    """Test basic Arrow table hashing with order invariance."""
 
-    h_a = hash_arrow_table(a, method=method)
-    h_a1 = hash_arrow_table(a, method=method)
-    h_b = hash_arrow_table(b, method=method)
-    h_c = hash_arrow_table(c, method=method)
-    h_d = hash_arrow_table(d, method=method)
-    h_e = hash_arrow_table(e, method=method)
-    h_f = hash_arrow_table(f, method=method)
-    h_g = hash_arrow_table(g, method=method)
-    h_h = hash_arrow_table(h, method=method)
-    h_i = hash_arrow_table(i, method=method)
-    h_j = hash_arrow_table(j, method=method)
+    @classmethod
+    def setup_class(cls):
+        """Set up test data for basic hashing tests."""
+        cls.tables = {
+            "original": pa.Table.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            "field_reordered": pa.Table.from_pydict({"b": [4, 5, 6], "a": [1, 2, 3]}),
+            "row_reordered": pa.Table.from_pydict({"a": [3, 2, 1], "b": [6, 5, 4]}),
+            "both_reordered": pa.Table.from_pydict({"b": [6, 5, 4], "a": [3, 2, 1]}),
+            "empty": pa.Table.from_pydict({"a": [], "b": []}),
+            "different_data": pa.Table.from_pydict({"a": [1, 2, 3], "b": [4, 5, 7]}),
+            "content_swapped": pa.Table.from_pydict({"b": [1, 2, 3], "a": [4, 5, 6]}),
+        }
 
-    # Basic type check
-    assert isinstance(h_a, bytes)
-    # Basic invariance checks
-    assert h_a == h_a1 == h_b == h_c == h_d
-    # Different data = different hashes
-    assert h_a != h_e
-    assert h_a != h_f
-    assert h_a != h_g
-    assert h_a != h_j
-    # List type table should be consistent regardless of field order
-    assert h_h == h_i
+    def test_order_invariance(self, method: HashMethod):
+        """Test that field and row order don't affect hash values."""
+        # Calculate all hashes
+        hashes = {
+            name: hash_arrow_table(table, method=method)
+            for name, table in self.tables.items()
+        }
+
+        # All hashes should be bytes
+        assert all(isinstance(h, bytes) for h in hashes.values())
+
+        # These should all hash identically despite different ordering
+        equivalent_tables = [
+            "original",
+            "field_reordered",
+            "row_reordered",
+            "both_reordered",
+        ]
+        equivalent_hashes = [hashes[name] for name in equivalent_tables]
+        assert all(h == equivalent_hashes[0] for h in equivalent_hashes), (
+            "Tables with same data but different ordering should hash identically"
+        )
+
+        # These should all hash differently
+        different_tables = ["empty", "different_data", "content_swapped"]
+        for table_name in different_tables:
+            assert hashes["original"] != hashes[table_name], (
+                f"Table '{table_name}' should hash differently from original"
+            )
+
+    def test_consistency_across_calls(self, method: HashMethod):
+        """Test that identical tables always produce the same hash."""
+        table = self.tables["original"]
+
+        hash1 = hash_arrow_table(table, method=method)
+        hash2 = hash_arrow_table(table, method=method)
+
+        assert hash1 == hash2, "Identical calls should produce identical hashes"
+
+    def test_list_fields_order_invariance(self, method: HashMethod):
+        """Test that order within list fields doesn't affect hash."""
+        table_ordered = pa.Table.from_pydict(
+            {
+                "a": [1, 2, 3],
+                "b": [[1, 2], [3, 4], [5, 6]],
+            }
+        )
+        table_list_reordered = pa.Table.from_pydict(
+            {
+                "a": [1, 2, 3],
+                "b": [[2, 1], [4, 3], [6, 5]],  # List elements reordered
+            }
+        )
+
+        hash_ordered = hash_arrow_table(table_ordered, method=method)
+        hash_reordered = hash_arrow_table(table_list_reordered, method=method)
+
+        assert hash_ordered == hash_reordered, (
+            "Order of elements within list fields should not affect hash"
+        )
+
+    def test_binary_fields_handling(self, method: HashMethod):
+        """Test that binary fields including non-UTF-8 bytes are handled correctly."""
+        table_with_binary = pa.Table.from_pydict(
+            {
+                "a": [1, 2, 3],
+                "b": [b"abc", None, bytes([255, 254, 253])],  # Include non-UTF-8 bytes
+            }
+        )
+
+        hash_result = hash_arrow_table(table_with_binary, method=method)
+        assert isinstance(hash_result, bytes), "Should successfully hash binary data"
 
 
 @pytest.mark.parametrize(
-    ["method"],
+    "method",
     [
         pytest.param(HashMethod.SHA256, id="sha256"),
         pytest.param(HashMethod.XXH3_128, id="xxh3_128"),
     ],
 )
-def test_struct_json_hashing(method: HashMethod):
-    """Test that struct/JSON data can be properly hashed."""
+class TestStructHashing:
+    """Test hashing of struct/JSON data within Arrow tables."""
 
-    # Basic struct test
-    a = pa.Table.from_pydict(
-        {
-            "id": [1, 2, 3],
-            "metadata": [
-                {"name": "Alice", "age": 30},
-                {"name": "Bob", "age": 25},
-                {"name": "Charlie", "age": 35},
-            ],
+    @classmethod
+    def setup_class(cls):
+        """Set up test data for struct hashing tests."""
+        cls.tables = {
+            "basic_struct": pa.Table.from_pydict(
+                {
+                    "id": [1, 2, 3],
+                    "metadata": [
+                        {"name": "Alice", "age": 30},
+                        {"name": "Bob", "age": 25},
+                        {"name": "Charlie", "age": 35},
+                    ],
+                }
+            ),
+            "struct_fields_reordered": pa.Table.from_pydict(
+                {
+                    "id": [1, 2, 3],
+                    "metadata": [
+                        {"age": 30, "name": "Alice"},
+                        {"age": 25, "name": "Bob"},
+                        {"age": 35, "name": "Charlie"},
+                    ],
+                }
+            ),
+            "struct_data_changed": pa.Table.from_pydict(
+                {
+                    "id": [1, 2, 3],
+                    "metadata": [
+                        {"name": "Alice", "age": 31},  # Changed age
+                        {"name": "Bob", "age": 25},
+                        {"name": "Charlie", "age": 35},
+                    ],
+                }
+            ),
+            "nested_struct": pa.Table.from_pydict(
+                {
+                    "id": [1, 2, 3],
+                    "metadata": [
+                        {
+                            "name": "Alice",
+                            "details": {"city": "New York", "active": True},
+                        },
+                        {"name": "Bob", "details": {"city": "Boston", "active": False}},
+                        {
+                            "name": "Charlie",
+                            "details": {"city": "Chicago", "active": True},
+                        },
+                    ],
+                }
+            ),
         }
-    )
 
-    assert isinstance(pl.from_arrow(a)["metadata"].dtype, pl.Struct)
+    def test_struct_field_order_invariance(self, method: HashMethod):
+        """Test that order of fields within structs doesn't affect hash."""
+        table_basic = self.tables["basic_struct"]
+        table_reordered = self.tables["struct_fields_reordered"]
 
-    # Same data but different struct serialization
-    b = pa.Table.from_pydict(
-        {
-            "id": [1, 2, 3],
-            "metadata": [
-                {"age": 30, "name": "Alice"},
-                {"age": 25, "name": "Bob"},
-                {"age": 35, "name": "Charlie"},
-            ],
+        # Verify we're actually testing struct data
+        df = pl.from_arrow(table_basic)
+        assert isinstance(df["metadata"].dtype, pl.Struct), (
+            "Test should be working with struct data type"
+        )
+
+        hash_basic = hash_arrow_table(table_basic, method=method)
+        hash_reordered = hash_arrow_table(table_reordered, method=method)
+
+        assert hash_basic == hash_reordered, (
+            "Struct field order should not affect hash value"
+        )
+
+    def test_struct_content_sensitivity(self, method: HashMethod):
+        """Test that changes in struct content produce different hashes."""
+        hash_basic = hash_arrow_table(self.tables["basic_struct"], method=method)
+        hash_changed = hash_arrow_table(
+            self.tables["struct_data_changed"], method=method
+        )
+        hash_nested = hash_arrow_table(self.tables["nested_struct"], method=method)
+
+        assert hash_basic != hash_changed, (
+            "Changed struct content should produce different hash"
+        )
+        assert hash_basic != hash_nested, (
+            "Different struct structure should produce different hash"
+        )
+
+    def test_nested_struct_consistency(self, method: HashMethod):
+        """Test that nested structs are handled consistently."""
+        table = self.tables["nested_struct"]
+
+        hash1 = hash_arrow_table(table, method=method)
+        hash2 = hash_arrow_table(table, method=method)
+
+        assert hash1 == hash2, "Nested structs should hash consistently"
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        pytest.param(HashMethod.SHA256, id="sha256"),
+        pytest.param(HashMethod.XXH3_128, id="xxh3_128"),
+    ],
+)
+class TestNormalisation:
+    """Test ID normalisation functionality in Arrow table hashing."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set up test data for normalisation tests."""
+        cls.tables = {
+            "original": pa.Table.from_pydict(
+                {
+                    "left_id": [1, 2, 3],
+                    "right_id": [4, 5, 6],
+                    "probability": [0.8, 0.9, 0.7],
+                }
+            ),
+            "ids_swapped": pa.Table.from_pydict(
+                {
+                    "left_id": [4, 5, 6],
+                    "right_id": [1, 2, 3],
+                    "probability": [0.8, 0.9, 0.7],
+                }
+            ),
+            "data_changed": pa.Table.from_pydict(
+                {
+                    "left_id": [1, 2, 3],
+                    "right_id": [4, 5, 6],
+                    "probability": [0.8, 0.9, 0.8],  # Changed last probability
+                }
+            ),
+            "rows_reordered": pa.Table.from_pydict(
+                {
+                    "left_id": [2, 1, 3],
+                    "right_id": [5, 4, 6],
+                    "probability": [0.9, 0.8, 0.7],
+                }
+            ),
+            "with_nulls_a": pa.Table.from_pydict(
+                {
+                    "left_id": [1, None, 3],
+                    "right_id": [None, 5, 6],
+                    "probability": [0.8, 0.9, 0.7],
+                }
+            ),
+            "with_nulls_b": pa.Table.from_pydict(
+                {
+                    "left_id": [None, 5, 6],
+                    "right_id": [1, None, 3],
+                    "probability": [0.8, 0.9, 0.7],
+                }
+            ),
+            "with_duplicates": pa.Table.from_pydict(
+                {
+                    "left_id": [1, 1, 2],
+                    "right_id": [1, 2, 1],
+                    "probability": [0.8, 0.9, 0.7],
+                }
+            ),
+            "empty": pa.Table.from_pydict(
+                {
+                    "left_id": [],
+                    "right_id": [],
+                    "probability": [],
+                }
+            ),
         }
-    )
 
-    # Different data in structs
-    c = pa.Table.from_pydict(
-        {
-            "id": [1, 2, 3],
-            "metadata": [
-                {"name": "Alice", "age": 31},  # Changed age
-                {"name": "Bob", "age": 25},
-                {"name": "Charlie", "age": 35},
-            ],
-        }
-    )
+    def test_normalisation_disabled_by_default(self, method: HashMethod):
+        """Test that without normalisation, ID order affects hash."""
+        table_original = self.tables["original"]
+        table_swapped = self.tables["ids_swapped"]
 
-    # Nested structs
-    d = pa.Table.from_pydict(
-        {
-            "id": [1, 2, 3],
-            "metadata": [
-                {"name": "Alice", "details": {"city": "New York", "active": True}},
-                {"name": "Bob", "details": {"city": "Boston", "active": False}},
-                {"name": "Charlie", "details": {"city": "Chicago", "active": True}},
-            ],
-        }
-    )
+        hash_original = hash_arrow_table(table_original, method=method)
+        hash_swapped = hash_arrow_table(table_swapped, method=method)
 
-    # Test basic struct hashing
-    h_a = hash_arrow_table(a, method=method)
-    h_a1 = hash_arrow_table(a, method=method)
-    h_b = hash_arrow_table(b, method=method)
-    h_c = hash_arrow_table(c, method=method)
-    h_d = hash_arrow_table(d, method=method)
+        assert hash_original != hash_swapped, (
+            "Without normalisation, swapped IDs should produce different hashes"
+        )
 
-    # Basic type check
-    assert isinstance(h_a, bytes)
+    def test_normalisation_makes_id_order_irrelevant(self, method: HashMethod):
+        """Test that normalisation makes ID column order irrelevant."""
+        normalise_cols = ["left_id", "right_id"]
 
-    # Basic equality check
-    assert h_a == h_a1 == h_b
-    # Difference checks
-    assert h_a != h_c
-    assert h_a != h_d
+        tables_to_test = ["original", "ids_swapped", "rows_reordered"]
+        hashes = []
+
+        for table_name in tables_to_test:
+            table = self.tables[table_name]
+            hash_val = hash_arrow_table(table, method=method, normalise=normalise_cols)
+            hashes.append(hash_val)
+
+        # All should be equal despite different ID arrangements
+        assert all(h == hashes[0] for h in hashes), (
+            "Normalisation should make ID order irrelevant"
+        )
+
+        # But different data should still produce different hash
+        hash_different = hash_arrow_table(
+            self.tables["data_changed"], method=method, normalise=normalise_cols
+        )
+        assert hashes[0] != hash_different, (
+            "Different data should still produce different hash even with normalisation"
+        )
+
+    def test_normalisation_with_multiple_columns(self, method: HashMethod):
+        """Test normalisation across more than two columns."""
+        table_abc = pa.Table.from_pydict(
+            {
+                "person_a": [1, 2, 3],
+                "person_b": [4, 5, 6],
+                "person_c": [7, 8, 9],
+                "score": [0.8, 0.9, 0.7],
+            }
+        )
+
+        # Same relationships but people in different columns
+        table_cab = pa.Table.from_pydict(
+            {
+                "person_a": [7, 8, 9],  # person_c values
+                "person_b": [1, 2, 3],  # person_a values
+                "person_c": [4, 5, 6],  # person_b values
+                "score": [0.8, 0.9, 0.7],
+            }
+        )
+
+        normalise_cols = ["person_a", "person_b", "person_c"]
+        hash_abc = hash_arrow_table(table_abc, method=method, normalise=normalise_cols)
+        hash_cab = hash_arrow_table(table_cab, method=method, normalise=normalise_cols)
+
+        assert hash_abc == hash_cab, (
+            "Multi-column normalisation should handle arbitrary column reordering"
+        )
+
+    def test_normalisation_handles_nulls(self, method: HashMethod):
+        """Test that normalisation works correctly with null values."""
+        normalise_cols = ["left_id", "right_id"]
+
+        hash_a = hash_arrow_table(
+            self.tables["with_nulls_a"], method=method, normalise=normalise_cols
+        )
+        hash_b = hash_arrow_table(
+            self.tables["with_nulls_b"], method=method, normalise=normalise_cols
+        )
+
+        assert hash_a == hash_b, "Normalisation should handle null values correctly"
+
+    def test_normalisation_edge_cases(self, method: HashMethod):
+        """Test normalisation with edge cases like duplicates and empty tables."""
+        normalise_cols = ["left_id", "right_id"]
+
+        # Test with duplicate values
+        table_dupes = self.tables["with_duplicates"]
+        hash_dupes = hash_arrow_table(
+            table_dupes, method=method, normalise=normalise_cols
+        )
+        assert isinstance(hash_dupes, bytes), (
+            "Should handle duplicate values in normalised columns"
+        )
+
+        # Test with empty table
+        table_empty = self.tables["empty"]
+        hash_empty = hash_arrow_table(
+            table_empty, method=method, normalise=normalise_cols
+        )
+        assert hash_empty == b"empty_table_hash", (
+            "Empty tables should return consistent special hash value"
+        )

--- a/test/common/test_hash.py
+++ b/test/common/test_hash.py
@@ -367,14 +367,16 @@ class TestNormalisation:
 
     def test_normalisation_makes_id_order_irrelevant(self, method: HashMethod):
         """Test that normalisation makes ID column order irrelevant."""
-        normalise_cols = ["left_id", "right_id"]
+        sorted_list_cols = ["left_id", "right_id"]
 
         tables_to_test = ["original", "ids_swapped", "rows_reordered"]
         hashes = []
 
         for table_name in tables_to_test:
             table = self.tables[table_name]
-            hash_val = hash_arrow_table(table, method=method, normalise=normalise_cols)
+            hash_val = hash_arrow_table(
+                table, method=method, as_sorted_list=sorted_list_cols
+            )
             hashes.append(hash_val)
 
         # All should be equal despite different ID arrangements
@@ -384,7 +386,9 @@ class TestNormalisation:
 
         # But different data should still produce different hash
         hash_different = hash_arrow_table(
-            self.tables["data_changed"], method=method, normalise=normalise_cols
+            self.tables["data_changed"],
+            method=method,
+            as_sorted_list=sorted_list_cols,
         )
         assert hashes[0] != hash_different, (
             "Different data should still produce different hash even with normalisation"
@@ -411,9 +415,13 @@ class TestNormalisation:
             }
         )
 
-        normalise_cols = ["person_a", "person_b", "person_c"]
-        hash_abc = hash_arrow_table(table_abc, method=method, normalise=normalise_cols)
-        hash_cab = hash_arrow_table(table_cab, method=method, normalise=normalise_cols)
+        sorted_list_cols = ["person_a", "person_b", "person_c"]
+        hash_abc = hash_arrow_table(
+            table_abc, method=method, as_sorted_list=sorted_list_cols
+        )
+        hash_cab = hash_arrow_table(
+            table_cab, method=method, as_sorted_list=sorted_list_cols
+        )
 
         assert hash_abc == hash_cab, (
             "Multi-column normalisation should handle arbitrary column reordering"
@@ -421,34 +429,38 @@ class TestNormalisation:
 
     def test_normalisation_handles_nulls(self, method: HashMethod):
         """Test that normalisation works correctly with null values."""
-        normalise_cols = ["left_id", "right_id"]
+        sorted_list_cols = ["left_id", "right_id"]
 
         hash_a = hash_arrow_table(
-            self.tables["with_nulls_a"], method=method, normalise=normalise_cols
+            self.tables["with_nulls_a"],
+            method=method,
+            as_sorted_list=sorted_list_cols,
         )
         hash_b = hash_arrow_table(
-            self.tables["with_nulls_b"], method=method, normalise=normalise_cols
+            self.tables["with_nulls_b"],
+            method=method,
+            as_sorted_list=sorted_list_cols,
         )
 
         assert hash_a == hash_b, "Normalisation should handle null values correctly"
 
     def test_normalisation_edge_cases(self, method: HashMethod):
         """Test normalisation with edge cases like duplicates and empty tables."""
-        normalise_cols = ["left_id", "right_id"]
+        sorted_list_cols = ["left_id", "right_id"]
 
         # Test with duplicate values
         table_dupes = self.tables["with_duplicates"]
         hash_dupes = hash_arrow_table(
-            table_dupes, method=method, normalise=normalise_cols
+            table_dupes, method=method, as_sorted_list=sorted_list_cols
         )
         assert isinstance(hash_dupes, bytes), (
-            "Should handle duplicate values in normalised columns"
+            "Should handle duplicate values in sorted_listd columns"
         )
 
         # Test with empty table
         table_empty = self.tables["empty"]
         hash_empty = hash_arrow_table(
-            table_empty, method=method, normalise=normalise_cols
+            table_empty, method=method, as_sorted_list=sorted_list_cols
         )
         assert hash_empty == b"empty_table_hash", (
             "Empty tables should return consistent special hash value"


### PR DESCRIPTION
Caching model results wasn't working because ID order doesn't matter when rationalising about whether two sets of probabilities evaluate to the same clusters, but it _does_ matter when making the hash.

This PR adds a `normalise` argument to Arrow table hashing that lets you declare columns whose order can be ignored when hashing. This is basically the solution I used in #190 to show that a change in the methodology hadn't changed the results it produced.

## 🛠️ Changes proposed in this pull request

* Adds normalisation to `hash_arrow_table()` and uses it in `matchbox.server.postgres.utils.insert.insert_results()`
* Totally refactors the sprawling unit tests of the function so they're a bit more organised

I know I didn't have to refactor the unit tests but when I added coverage for normalisation the file became hard work to read.

## 👀 Guidance to review

* Read the unit tests overall
* Read the unit tests for normalisation and confirm they'd hash probabilities fairly
* Read anything left

## 🤖 AI declaration

Heavy use in refactoring the unit tests, but I've read them all through and it's all covered.

## 🔗 Relevant links

* #190 

## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
