### PR TITLE
Remove GitHub workflow redundant permissions

### DIFF
--- a/.github/workflows/docs-build-and-deploy.yml
+++ b/.github/workflows/docs-build-and-deploy.yml
@@ -41,10 +41,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     
-    permissions:
-      pages: write
-      id-token: write
-
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

* Fix syntax error in workflow YAML

## 👀 Guidance to review

Problem was permissions were being set twice. It was causing a workflow to fail.

## 🤖 AI declaration

None.

## 🔗 Relevant links

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
