### PR TITLE
Fixes Cluster so single clusters combine properly

### DIFF
--- a/src/matchbox/common/transform.py
+++ b/src/matchbox/common/transform.py
@@ -269,7 +269,16 @@ class Cluster:
         """
         clusters = list(clusters)
         if len(clusters) == 1:
-            return clusters[0]
+            new_probability = (
+                clusters[0].probability if probability is None else probability
+            )
+            return cls(
+                intmap=clusters[0]._intmap,
+                probability=new_probability,
+                leaves=clusters[0].leaves,
+                id=clusters[0].id,
+                hash=clusters[0].hash,
+            )
 
         intmap = clusters[0]._intmap
         unique_dict: dict[int, Cluster] = {}

--- a/test/common/test_transform.py
+++ b/test/common/test_transform.py
@@ -202,17 +202,38 @@ class TestClusterHierarchy:
         assert level2_cluster.probability == 80
 
     def test_combine_with_single_cluster(self, leaf_nodes: list[Cluster]):
-        """Test that combine works correctly with a single cluster."""
-        # Create a single-element list
-        clusters = [leaf_nodes[0]]
+        """Test that combine works correctly with a single cluster.
 
-        # Combine
-        result = Cluster.combine(clusters, probability=None)
+        When Cluster.combine() receives only one cluster but with a new probability,
+        it should pass that probability on.
+        """
+        # Take a leaf node (which has probability=None)
+        original_cluster = leaf_nodes[0]
+        assert original_cluster.probability is None
 
-        # Should return the original cluster
-        assert result is leaf_nodes[0]
-        # Verify probability as expected
-        assert result.probability is None
+        # Combine it with itself but provide a new probability
+        result = Cluster.combine([original_cluster], probability=85)
+
+        # Should get a new cluster with the specified probability
+        assert result.probability == 85
+        assert result.id == original_cluster.id
+        assert result.hash == original_cluster.hash
+        assert result.leaves == original_cluster.leaves
+
+        # Should be a different object (not the original)
+        assert result is not original_cluster
+
+        # Test with probability=0 (edge case)
+        result_zero = Cluster.combine([original_cluster], probability=0)
+        assert result_zero.probability == 0
+
+        # Test preserving original probability when None provided
+        result_none = Cluster.combine([original_cluster], probability=None)
+        assert result_none.probability is None
+
+        assert result_none.id == original_cluster.id
+        assert result_none.hash == original_cluster.hash
+        assert result_none.leaves == original_cluster.leaves
 
     def test_combine_with_leaf_and_non_leaf(
         self, intmap: IntMap, leaf_nodes: list[Cluster]
@@ -302,3 +323,40 @@ class TestClusterHierarchy:
             ]
         )
         assert top_level.hash == alternate_grouping.hash
+
+    def test_combine_single_cluster_with_new_probability(
+        self, leaf_nodes: list[Cluster]
+    ):
+        """Test that combine respects new probability even with single cluster.
+
+        When Cluster.combine() receives only one cluster but with a new probability,
+        it should create a new cluster with that probability rather than returning
+        the original cluster unchanged.
+        """
+        # Take a leaf node (which has probability=None)
+        original_cluster = leaf_nodes[0]
+        assert original_cluster.probability is None
+
+        # Combine it with itself but provide a new probability
+        result = Cluster.combine([original_cluster], probability=85)
+
+        # Should get a new cluster with the specified probability
+        assert result.probability == 85
+        assert result.id == original_cluster.id
+        assert result.hash == original_cluster.hash
+        assert result.leaves == original_cluster.leaves
+
+        # Should be a different object (not the original)
+        assert result is not original_cluster
+
+        # Test with probability=0 (edge case)
+        result_zero = Cluster.combine([original_cluster], probability=0)
+        assert result_zero.probability == 0
+
+        # Test preserving original probability when None provided
+        result_none = Cluster.combine([original_cluster], probability=None)
+        assert result_none.probability is None
+
+        assert result_none.id == original_cluster.id
+        assert result_none.hash == original_cluster.hash
+        assert result_none.leaves == original_cluster.leaves


### PR DESCRIPTION
We're [seeing a bug in production](https://dbt.datadoghq.eu/error-tracking?query=&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%2238bc7a2e-51bf-11f0-9b3e-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1750768833089&to_ts=1750855233089&live=true) where probabilities with `None` are attempting to be inserted.

This was caused by a self-join in the results:

```text
┌─────────┬──────────┬─────────────┐
│ left_id ┆ right_id ┆ probability │
│ ---     ┆ ---      ┆ ---         │
│ u64     ┆ u64      ┆ u8          │
╞═════════╪══════════╪═════════════╡
│ 719214  ┆ 719214   ┆ 100         │
└─────────┴──────────┴─────────────┘
```

Which tripped `Cluster.compose()`'s single-cluster logic, which stripped probabilities.

## 🛠️ Changes proposed in this pull request

* Fixes `Cluster.compose()` and amends a unit test to cover the proper behaviour

## 👀 Guidance to review

None.

## 🤖 AI declaration

Used to theorise about the bug.

## 🔗 Relevant links

* [Datadog bug traceback](https://dbt.datadoghq.eu/error-tracking?query=&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%2238bc7a2e-51bf-11f0-9b3e-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1750768833089&to_ts=1750855233089&live=true)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
