### PR TITLE
feature: alembic logging follows matchbox standard asim formatting

### DIFF
--- a/src/matchbox/server/postgresql/alembic.ini
+++ b/src/matchbox/server/postgresql/alembic.ini
@@ -12,7 +12,7 @@ keys = root,sqlalchemy,alembic
 keys = console
 
 [formatters]
-keys = generic
+keys = asim
 
 [logger_root]
 level = WARNING
@@ -33,11 +33,10 @@ qualname = alembic
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
-formatter = generic
+formatter = asim
 
-[formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
-datefmt = %H:%M:%S
+[formatter_asim]
+class=src.matchbox.common.logging.ASIMFormatter
 
 [post_write_hooks]
 hooks = ruff_format, ruff_lint


### PR DESCRIPTION
## Give high level context to this PR

This changes the logging formatting for alembic to follow the ASIM format used for the rest of matchbox. This then optimises it for datadog also, as well as in general being good to standardise.


## List the main changes you've made

Simpler than I initially thought, just had to point alembic.ini to the right place.


## Help reviewers know where to focus their efforts, or flag controversial decisions 

Quite a small MR.


## Declare code where AI was used, and how you ensured its quality 

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
