### PR TITLE
Add combine type argument to StepInput.

### DIFF
--- a/src/matchbox/client/dags.py
+++ b/src/matchbox/client/dags.py
@@ -3,7 +3,7 @@
 import datetime
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any
+from typing import Any, Literal
 
 import polars as pl
 from pyarrow import Table
@@ -60,6 +60,7 @@ class StepInput(BaseModel):
     cleaners: dict[str, dict[str, Any]] = {}
     batch_size: int | None = None
     threshold: float | None = None
+    combine_type: Literal["concat", "explode", "set_agg"] = "concat"
 
     @property
     def name(self) -> str:
@@ -164,6 +165,7 @@ class ModelStep(Step):
             threshold=step_input.threshold,
             resolution=step_input.name,
             batch_size=step_input.batch_size,
+            combine_type=step_input.combine_type,
         )
 
 


### PR DESCRIPTION
In later pipelines we may have multiple values for one field. Array aggregation from query helps us process them.

## 🛠️ Changes proposed in this pull request

* Adds combine type arg to `StepInput`

## 👀 Guidance to review

None.

## 🤖 AI declaration

Heavily used, but all reviewed.

## 🔗 Relevant links

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
