### PR TITLE
Changed RelationalDBLocation.head() to always exhaust the generator

### DIFF
--- a/src/matchbox/common/sources.py
+++ b/src/matchbox/common/sources.py
@@ -240,7 +240,9 @@ class RelationalDBLocation(Location):
         return validate_sql_for_data_extraction(extract_transform)
 
     def head(self, extract_transform: str) -> pl.DataFrame:  # noqa: D102
-        return next(self.execute(extract_transform.rstrip(" \t\n;") + " limit 100;"))
+        query = extract_transform.rstrip(" \t\n;") + " limit 100;"
+        batches = list(self.execute(query))
+        return batches[0]
 
     @requires_credentials
     def execute(  # noqa: D102


### PR DESCRIPTION
We're still getting weird connection issues. This ensures `RelationalDBLocation.head()` always exhausts `RelationalDBLocation.execute()`'s generator, which @michalc recommended. Reckon it's worth a go.

## 🛠️ Changes proposed in this pull request

* `RelationalDBLocation.head()`

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## 🔗 Relevant links

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
