### PR TITLE
bugfix: set dd_version as env var

### DIFF
--- a/src/matchbox/common/logging.py
+++ b/src/matchbox/common/logging.py
@@ -5,7 +5,6 @@ import logging
 import os
 from datetime import datetime, timezone
 from functools import cached_property
-from importlib.metadata import version
 from typing import Any, Final, Literal
 
 from rich.console import Console
@@ -98,11 +97,6 @@ class ASIMFormatter(logging.Formatter):
         return str((1 << 64) - 1 & trace_id)
 
     @cached_property
-    def matchbox_version(self) -> str:
-        """Cached matchbox version."""
-        return version("matchbox_db")
-
-    @cached_property
     def event_severity(self) -> dict[str, str]:
         """Event severity level lookup."""
         return {
@@ -137,6 +131,14 @@ class ASIMFormatter(logging.Formatter):
         This environment variable is set by the ECS task definition.
         """
         return os.getenv("DD_SERVICE", default="")
+
+    @cached_property
+    def version(self) -> str:
+        """Datadog's version value.
+
+        This environment variable is set in the Dockerfile for the task.
+        """
+        return os.getenv("DD_VERSION", default="")
 
     def get_trace_id_span_id(self) -> tuple[str | None, str | None]:
         """Retrieve's Datadog's trace ID and span ID variables.
@@ -180,7 +182,7 @@ class ASIMFormatter(logging.Formatter):
                 "dd.span_id": span_id,
                 "dd.team": "matchbox",
                 "dd.trace_id": trace_id,
-                "dd.version": self.matchbox_version,
+                "dd.version": self.version,
                 "message": record.getMessage(),
             },
         )

--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /code
 ARG MB_VERSION
 RUN if [ -z "$MB_VERSION" ]; then echo 'Environment variable MB_VERSION must be specified. Exiting.'; exit 1; fi
 ENV MB_VERSION=${MB_VERSION}
-
+ENV DD_VERSION=${MB_VERSION}
 
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1494,7 +1493,6 @@ requires-dist = [
     { name = "streamlit", marker = "extra == 'eval'", specifier = ">=1.45.0" },
     { name = "tomli", marker = "extra == 'server'", specifier = ">=2.0.1" },
 ]
-provides-extras = ["server", "eval"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

Set DD_VERSION as an env var in the Dockerfile to ensure it is always present as it is expected by DataDog. I realised that this was being set for logs but as it wasn't present as an env var then metrics may not be properly matched to the logs representing the same version of code deployed (I hadn't actually noticed any issue, so perhaps DataDog infers if it is missing given it also knows Service and Env but since the docs stress all three are expected it seems best to ensure it is there).

## 👀 Guidance to review

None.


## 🤖 AI declaration

None.

## 🔗 Relevant links

https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=ecs#containerized-environment


## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [ ] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
