### PR TITLE
Use location names instead of URIs

### DIFF
--- a/docs/api/server/backends/postgresql.md
+++ b/docs/api/server/backends/postgresql.md
@@ -13,7 +13,7 @@ erDiagram
         bigint source_config_id PK
         bigint resolution_id FK
         string location_type
-        string location_uri
+        string location_name
         string extract_transform
     }
     SourceFields {

--- a/docs/client/link-data.md
+++ b/docs/client/link-data.md
@@ -62,7 +62,7 @@ The `key_field` is the field in your source that contains some unique code that 
     # Companies House data
     companies_house = SourceConfig.new(
         name="companies_house",
-        location=RelationalDBLocation.from_engine(engine),
+        location=RelationalDBLocation(name="dbname", credentials=engine),
         extract_transform="""
             select
                 pk as id,
@@ -79,7 +79,7 @@ The `key_field` is the field in your source that contains some unique code that 
     # Exporters data
     exporters = SourceConfig.new(
         name="hmrc_exporters",
-        location=RelationalDBLocation.from_engine(engine),
+        location=RelationalDBLocation(name="dbname", credentials=engine),
         extract_transform="""
             select
                 id,
@@ -95,8 +95,8 @@ The `key_field` is the field in your source that contains some unique code that 
 
 Each [`SourceConfig`][matchbox.common.sources.SourceConfig] object requires:
 
-- A `location`, such as [`RelationalDBLocation`][matchbox.common.sources.RelationalDBLocation]. This will need a `type`, a `uri`, and `credentials`, the type of which changes depending on the type of location you're using
-    - For most users [`RelationalDBLocation`][matchbox.common.sources.RelationalDBLocation] and its `.from_engine()` constructor is all you need
+- A `location`, such as [`RelationalDBLocation`][matchbox.common.sources.RelationalDBLocation]. This will need a `type`, a `name`, and `credentials`, the type of which changes depending on the type of location you're using
+    - The name of a location is a way of tagging it, such that later on you can filter source configs you want to retrieve from the server
     - For a relational database, a SQLAlchemy engine is your credentials
 - An `extract_transform` string, which will take data from the location and transform it into your key and index fields. Its syntax will depend on the type of location
     - For most users, using a relational database location, this will be SQL
@@ -114,7 +114,7 @@ If a `SourceConfig` has already been created you can fetch it, with optional val
     # Companies House data
     companies_house = get_source(
         name="companies_house",
-        location=RelationalDBLocation.from_engine(engine),
+        location=RelationalDBLocation(name="dbname", credentials=engine),
         extract_transform="""
             select
                 pk as id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dev = [
     "mkdocstrings[python]>=0.27.0",
     "moto[s3]>=5.0.26",
     "pre-commit>=3.8.0",
-    "psycopg2>=2.9.10",
     "pytest>=8.3.3",
     "pytest-asyncio>=0.25.2",
     "pytest-cov>=5.0.0",

--- a/src/matchbox/client/dags.py
+++ b/src/matchbox/client/dags.py
@@ -447,7 +447,7 @@ class DAG:
             debug_sqlite_uri = "sqlite:///:memory:"
             debug_engine = create_engine(debug_sqlite_uri)
             debug_location = RelationalDBLocation(
-                uri=debug_sqlite_uri, credentials=debug_engine
+                name="__DEBUG__", credentials=debug_engine
             )
 
         for step_name in self.sequence[start_index:end_index]:

--- a/src/matchbox/client/eval/ui.py
+++ b/src/matchbox/client/eval/ui.py
@@ -21,6 +21,7 @@ def fetch_samples():
             n=100,
             resolution=st.session_state.resolution,
             user_id=st.session_state.user_id,
+            use_default_credentials=True,
         )
     st.session_state.step = "eval" if st.session_state.samples else "done"
 

--- a/src/matchbox/client/eval/utils.py
+++ b/src/matchbox/client/eval/utils.py
@@ -25,6 +25,7 @@ def get_samples(
     user_id: int,
     resolution: ModelResolutionName | None = None,
     credentials: Any | None = None,
+    # TODO: allow different credentials per location name
 ) -> dict[int, pl.DataFrame]:
     """Retrieve samples enriched with source data, grouped by resolution cluster.
 

--- a/src/matchbox/client/extract.py
+++ b/src/matchbox/client/extract.py
@@ -9,34 +9,24 @@ from matchbox.common.graph import ModelResolutionName, SourceResolutionName
 
 def key_field_map(
     resolution: ModelResolutionName,
-    source_filter: list[SourceResolutionName] | SourceResolutionName | None = None,
-    uri_filter: list[str] | str | None = None,
+    source_filter: list[SourceResolutionName] | None = None,
+    location_names: list[str] | None = None,
 ) -> ArrowTable:
     """Return matchbox IDs to source key mapping, optionally filtering.
 
     Args:
         resolution: The resolution name to use for the query.
-        source_filter: A substring or list of substrings to filter source names.
-        uri_filter: A substring or list of substrings to filter location URIs.
+        source_filter: An optional list of source resolution names to filter by.
+        location_names: An optional list of location names to filter by.
     """
     # Get all sources in scope of the resolution
     sources = _handler.get_resolution_source_configs(name=resolution)
 
     if source_filter:
-        if isinstance(source_filter, str):
-            source_filter = [source_filter]
-
-        # Filter sources by name
         sources = [s for s in sources if s.name in source_filter]
 
-    if uri_filter:
-        if isinstance(uri_filter, str):
-            uri_filter = [uri_filter]
-
-        # Filter sources by location URI
-        sources = [
-            s for s in sources if any(sub in str(s.location.uri) for sub in uri_filter)
-        ]
+    if location_names:
+        sources = [s for s in sources if s.location.name in location_names]
 
     if not sources:
         raise MatchboxSourceNotFoundError("No compatible source was found")

--- a/src/matchbox/common/factories/sources.py
+++ b/src/matchbox/common/factories/sources.py
@@ -468,6 +468,7 @@ def generate_source(
 def source_factory(
     features: list[FeatureConfig] | list[dict] | None = None,
     name: SourceResolutionName | None = None,
+    location_name: str = "dbname",
     engine: Engine | None = None,
     n_true_entities: int = 10,
     repetition: int = 0,
@@ -484,6 +485,7 @@ def source_factory(
         name: Name of the source. If None, a unique name is generated. This will be
             used as the name of the table in the RelationalDBLocation, but also as
             the SourceResolutionName for the source.
+        location_name: Name of the location for the source.
         engine: SQLAlchemy engine to use for the source's RelationalDBLocation. If
             None, an in-memory SQLite engine is created.
         n_true_entities: Number of true entities to generate. Defaults to 10.
@@ -553,7 +555,7 @@ def source_factory(
 
     # Create source config
     source_config = SourceConfig(
-        location=RelationalDBLocation(uri=str(engine.url)),
+        location=RelationalDBLocation(name=location_name),
         name=name,
         extract_transform=select(
             cast(column(key_field.name), "string").as_(key_field.name),
@@ -578,6 +580,7 @@ def source_from_tuple(
     data_tuple: tuple[dict[str, Any], ...],
     data_keys: tuple[Any],
     name: str | None = None,
+    location_name: str = "dbname",
     engine: Engine | None = None,
     seed: int = 42,
 ) -> SourceTestkit:
@@ -618,7 +621,7 @@ def source_from_tuple(
 
     # Create source config
     source_config = SourceConfig(
-        location=RelationalDBLocation(uri=str(engine.url)),
+        location=RelationalDBLocation(name=location_name),
         name=name,
         extract_transform=select(
             cast(column(key_field.name), "string").as_(key_field.name),
@@ -830,7 +833,7 @@ def linked_sources_factory(
 
         # Create source config
         source_config = SourceConfig(
-            location=RelationalDBLocation(uri=str(parameters.engine.url)),
+            location=RelationalDBLocation(name=str(parameters.name)),
             name=parameters.name,
             extract_transform=select(
                 cast(column(key_field.name), "string").as_(key_field.name),

--- a/src/matchbox/server/postgresql/alembic/versions/7a2d1b10ac0f_switch_from_location_uri_to_name.py
+++ b/src/matchbox/server/postgresql/alembic/versions/7a2d1b10ac0f_switch_from_location_uri_to_name.py
@@ -20,20 +20,36 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    # TODO: add location name to all existing rows
+    # Add default value for rows without location names
     op.add_column(
         "source_configs",
-        sa.Column("location_name", sa.TEXT(), nullable=False),
+        sa.Column(
+            "location_name",
+            sa.TEXT(),
+            nullable=False,
+            server_default="legacy",
+        ),
         schema="mb",
     )
+    # Remove default value for location names
+    op.alter_column("source_configs", "location_name", server_default=None, schema="mb")
     op.drop_column("source_configs", "location_uri", schema="mb")
 
 
 def downgrade() -> None:
     """Downgrade schema."""
+    # Add default value for rows without location URIs
     op.add_column(
         "source_configs",
-        sa.Column("location_uri", sa.TEXT(), autoincrement=False, nullable=False),
+        sa.Column(
+            "location_uri",
+            sa.TEXT(),
+            autoincrement=False,
+            nullable=False,
+            server_default="sqlite:///:memory:",
+        ),
         schema="mb",
     )
+    # Remove default value for location URIs
+    op.alter_column("source_configs", "location_uri", server_default=None, schema="mb")
     op.drop_column("source_configs", "location_name", schema="mb")

--- a/src/matchbox/server/postgresql/alembic/versions/7a2d1b10ac0f_switch_from_location_uri_to_name.py
+++ b/src/matchbox/server/postgresql/alembic/versions/7a2d1b10ac0f_switch_from_location_uri_to_name.py
@@ -1,0 +1,39 @@
+"""Switch from location URI to name.
+
+Revision ID: 7a2d1b10ac0f
+Revises: dd0c3a9ecdf9
+Create Date: 2025-07-29 07:52:36.312694
+
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7a2d1b10ac0f"
+down_revision: str | None = "dd0c3a9ecdf9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # TODO: add location name to all existing rows
+    op.add_column(
+        "source_configs",
+        sa.Column("location_name", sa.TEXT(), nullable=False),
+        schema="mb",
+    )
+    op.drop_column("source_configs", "location_uri", schema="mb")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "source_configs",
+        sa.Column("location_uri", sa.TEXT(), autoincrement=False, nullable=False),
+        schema="mb",
+    )
+    op.drop_column("source_configs", "location_name", schema="mb")

--- a/src/matchbox/server/postgresql/orm.py
+++ b/src/matchbox/server/postgresql/orm.py
@@ -361,7 +361,7 @@ class SourceConfigs(CountMixin, MBDB.MatchboxBase):
         nullable=False,
     )
     location_type = Column(TEXT, nullable=False)
-    location_uri = Column(TEXT, nullable=False)
+    location_name = Column(TEXT, nullable=False)
     extract_transform = Column(TEXT, nullable=False)
 
     @property
@@ -449,7 +449,7 @@ class SourceConfigs(CountMixin, MBDB.MatchboxBase):
         return cls(
             resolution_id=resolution.resolution_id,
             location_type=source_config.location.type,
-            location_uri=str(source_config.location.uri),
+            location_name=str(source_config.location.name),
             extract_transform=source_config.extract_transform,
             key_field=SourceFields(
                 index=0,
@@ -472,7 +472,7 @@ class SourceConfigs(CountMixin, MBDB.MatchboxBase):
             name=self.name,
             location={
                 "type": self.location_type,
-                "uri": self.location_uri,
+                "name": self.location_name,
             },
             extract_transform=self.extract_transform,
             key_field=CommonSourceField(

--- a/test/client/helpers/test_index_helper.py
+++ b/test/client/helpers/test_index_helper.py
@@ -203,7 +203,7 @@ def test_get_source_with_valid_location(
     [
         pytest.param(
             "location",
-            RelationalDBLocation(uri="different://location"),
+            RelationalDBLocation(name="other_location"),
             "does not match the provided location",
             id="location-mismatch",
         ),
@@ -247,7 +247,7 @@ def test_get_source_validation_mismatch(
         get_source("test_source", **kwargs)
 
 
-def test_get_source_404_error(matchbox_api: MockRouter, sqlite_warehouse: Engine):
+def test_get_source_404_error(matchbox_api: MockRouter):
     """Test get_source handles 404 source not found error."""
     matchbox_api.get("/sources/nonexistent").mock(
         return_value=Response(

--- a/test/client/helpers/test_misc_helper.py
+++ b/test/client/helpers/test_misc_helper.py
@@ -103,12 +103,12 @@ def test_select_default_engine(
     )
 
     # Select sources
-    selection = select("bar")
+    selection = select("bar")[0]
 
     # Check selector contains what we expect
-    assert set(f.name for f in selection[0].fields) == {"a", "b"}
-    assert selection[0].source.name == "bar"
-    assert str(selection[0].source.location.uri) == str(sqlite_warehouse.url)
+    assert set(f.name for f in selection.fields) == {"a", "b"}
+    assert selection.source.name == "bar"
+    assert str(selection.source.location.credentials.url) == str(sqlite_warehouse.url)
 
 
 def test_select_missing_credentials():

--- a/test/client/test_extract.py
+++ b/test/client/test_extract.py
@@ -21,12 +21,14 @@ def test_key_field_map(
 
     foo = source_from_tuple(
         name="foo",
+        location_name="sqlite",
         engine=sqlite_warehouse,
         data_keys=[1, 2, 3],
         data_tuple=({"col": 0}, {"col": 1}, {"col": 2}),
     )
     bar = source_from_tuple(
         name="bar",
+        location_name="sqlite_memory",
         engine=sqlite_memory_warehouse,
         data_keys=["a", "b", "c"],
         data_tuple=({"col": 10}, {"col": 11}, {"col": 12}),
@@ -96,16 +98,11 @@ def test_key_field_map(
         key_field_map(resolution="companies", source_filter=["nonexistent"])
 
     with pytest.raises(MatchboxSourceNotFoundError):
-        key_field_map(resolution="companies", uri_filter="postgresql://")
-
-    with pytest.raises(MatchboxSourceNotFoundError):
-        key_field_map(resolution="companies", uri_filter=["nonexistent"])
+        key_field_map(resolution="companies", location_names=["nonexistent"])
 
     # Case 1: Retrieve single table
     # With URI filter
-    foo_mapping = key_field_map(
-        resolution="companies", uri_filter=str(sqlite_warehouse.url)
-    )
+    foo_mapping = key_field_map(resolution="companies", location_names=["sqlite"])
 
     assert_frame_equal(
         pl.from_arrow(foo_mapping),
@@ -128,7 +125,7 @@ def test_key_field_map(
     foo_mapping = key_field_map(
         resolution="companies",
         source_filter="foo",
-        uri_filter=str(sqlite_warehouse.url),
+        location_names="sqlite",
     )
 
     assert_frame_equal(

--- a/test/common/factories/test_source_factory.py
+++ b/test/common/factories/test_source_factory.py
@@ -183,16 +183,18 @@ def test_source_factory_mock_properties():
     ]
 
     name = "companies"
+    location_name = "custom_name"
     engine = create_engine("sqlite:///:memory:")
 
     source_config = source_factory(
         features=features,
         name=name,
+        location_name=location_name,
         engine=engine,
     ).source_config
 
     # Location should be consistent
-    expected_location = RelationalDBLocation(uri=str(engine.url))
+    expected_location = RelationalDBLocation(name=location_name)
     assert source_config.location == expected_location
 
     # Check indexed fields configuration
@@ -208,7 +210,7 @@ def test_source_factory_mock_properties():
     # Verify source properties are preserved through model_dump
     dump = source_config.model_dump()
     assert dump["name"] == name
-    assert str(dump["location"]["uri"]) == str(engine.url)
+    assert str(dump["location"]["name"]) == location_name
     assert dump["key_field"] == {"name": "key", "type": DataTypes.STRING}
     assert dump["index_fields"] == tuple(
         {"name": f.name, "type": f.datatype} for f in features

--- a/test/common/test_sources.py
+++ b/test/common/test_sources.py
@@ -4,8 +4,8 @@ import polars as pl
 import pyarrow as pa
 import pytest
 from polars.testing import assert_frame_equal
-from pydantic import AnyUrl, ValidationError
-from sqlalchemy import Engine, create_engine
+from pydantic import ValidationError
+from sqlalchemy import Engine
 from sqlalchemy.exc import OperationalError
 from sqlglot import select
 from sqlglot.errors import ParseError
@@ -28,16 +28,16 @@ from matchbox.common.sources import (
 
 def test_location_empty_credentials_error():
     """Test that operations requiring credentials fail when credentials are not set."""
-    location = RelationalDBLocation(uri="postgresql://host:1234/db2")
+    location = RelationalDBLocation(name="dbname")
 
     # Attempting to connect without credentials should raise an error
     with pytest.raises(MatchboxSourceCredentialsError):
         location.connect()
 
 
-def test_location_serialisation():
+def test_location_serialisation(sqlite_warehouse: Engine):
     """Test serialisation and deserialisation of Location objects."""
-    original = RelationalDBLocation(uri="postgresql://host:1234/db2")
+    original = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
 
     # Convert to dict and back - credentials should be excluded
     location_dict = original.model_dump()
@@ -45,129 +45,15 @@ def test_location_serialisation():
 
     # Deserialize back to a Location
     reconstructed = RelationalDBLocation.model_validate(location_dict)
-    assert reconstructed.uri == original.uri
     assert reconstructed.type == original.type
     assert reconstructed.credentials is None
 
 
 def test_relational_db_location_instantiation():
     """Test that RelationalDBLocation can be instantiated with valid parameters."""
-    location = RelationalDBLocation(uri="sqlite:///test.db")
+    location = RelationalDBLocation(name="dbname")
     assert location.type == "rdbms"
-    assert str(location.uri) == "sqlite:///test.db"
     assert location.credentials is None
-
-
-@pytest.mark.parametrize(
-    ["uri", "expected"],
-    [
-        pytest.param("sqlite:///test.db", "sqlite:///test.db", id="valid-sqlite"),
-        pytest.param(
-            "postgresql://localhost:5432/testdb",
-            "postgresql://localhost:5432/testdb",
-            id="valid-postgres",
-        ),
-        pytest.param(
-            "postgresql://user:pass@localhost:5432/testdb",
-            "postgresql://localhost:5432/testdb",
-            id="credentials-in-uri",
-        ),
-        pytest.param(
-            "postgresql+psycopg://localhost:5432/testdb",
-            "postgresql://localhost:5432/testdb",
-            id="driver-in-uri",
-        ),
-        pytest.param(
-            "sqlite:///test.db?mode=ro", "sqlite:///test.db", id="query-params"
-        ),
-        pytest.param("sqlite:///test.db#fragment", "sqlite:///test.db", id="fragment"),
-        pytest.param(
-            "sqlite:///var/folders/14/6nvsrw1n2ls1xncz_bvy2x8m0000gq/T/db.sqlite",
-            "sqlite:///var/folders/14/6nvsrw1n2ls1xncz_bvy2x8m0000gq/T/db.sqlite",
-            id="no-hostname",
-        ),
-    ],
-)
-def test_relational_db_location_uri_clean(uri: str, expected: str):
-    """Test URI validation in RelationalDBLocation."""
-    location = RelationalDBLocation(uri=uri)
-    assert location.uri == AnyUrl(expected)
-
-
-def test_relational_db_add_credentials(sqlite_warehouse: Engine):
-    """Test the public interface for adding credentials to a RelationalDBLocation.
-
-    This test verifies:
-        1. Credentials are properly added and validated for matching engines
-        2. Validation fails for non-matching engines
-        3. Connect succeeds only with valid credentials
-    """
-    # Create engines and URIs
-    test_engines = {
-        # PostgreSQL engines with different connection parameters
-        "pg": create_engine("postgresql://user:pass@host:5432/db"),  # trufflehog:ignore
-        "pg_diff_host": create_engine(
-            "postgresql://user:pass@otherhost:5432/db"  # trufflehog:ignore
-        ),
-        "pg_diff_port": create_engine(
-            "postgresql://user:pass@host:5433/db"  # trufflehog:ignore
-        ),
-        "pg_diff_db": create_engine(
-            "postgresql://user:pass@host:5432/otherdb"  # trufflehog:ignore
-        ),
-        # These should match the same URI as "pg"
-        # (different user/pass/dialect don't affect matching)
-        "pg_diff_user": create_engine(
-            "postgresql://user2:pass@host:5432/db"  # trufflehog:ignore
-        ),
-        "pg_diff_pass": create_engine(
-            "postgresql://user:pass2@host:5432/db"  # trufflehog:ignore
-        ),
-        "pg_diff_dialect": create_engine(
-            "postgresql+psycopg://user:pass@host:5432/db"  # trufflehog:ignore
-        ),
-    }
-
-    uris = {
-        "pg": "postgresql://host:5432/db",
-        "pg_diff_host": "postgresql://otherhost:5432/db",
-        "pg_diff_port": "postgresql://host:5433/db",
-        "pg_diff_db": "postgresql://host:5432/otherdb",
-        "sqlite": str(sqlite_warehouse.url),
-    }
-
-    # Test case 1: Adding matching credentials succeeds
-    location1 = RelationalDBLocation(uri=uris["sqlite"])
-    location1.add_credentials(sqlite_warehouse)
-    assert location1.credentials == sqlite_warehouse
-    assert location1.connect() is True
-
-    # Test case 2: Adding mismatched credentials fails
-    location2 = RelationalDBLocation(uri=uris["pg"])
-    with pytest.raises(ValueError, match="does not match"):
-        location2.add_credentials(sqlite_warehouse)
-
-    # Test case 3: Check which parameters affect URI matching
-    # Group by expected URI matching behavior
-    should_match_pg = {"pg", "pg_diff_user", "pg_diff_pass", "pg_diff_dialect"}
-    should_not_match_pg = {"pg_diff_host", "pg_diff_port", "pg_diff_db"}
-
-    # Verify that add_credentials works for matching engines
-    base_pg_location = RelationalDBLocation(uri=uris["pg"])
-    base_pg_location.add_credentials(test_engines["pg"])
-    assert base_pg_location.credentials == test_engines["pg"]
-
-    # All engines in should_match_pg should work with this location
-    for engine_key in should_match_pg:
-        test_location = RelationalDBLocation(uri=uris["pg"])
-        test_location.add_credentials(test_engines[engine_key])
-        assert test_location.credentials == test_engines[engine_key]
-
-    # All engines in should_not_match_pg should fail with this location
-    for engine_key in should_not_match_pg:
-        test_location = RelationalDBLocation(uri=uris["pg"])
-        with pytest.raises(ValueError, match="does not match"):
-            test_location.add_credentials(test_engines[engine_key])
 
 
 @pytest.mark.parametrize(
@@ -221,7 +107,7 @@ def test_relational_db_add_credentials(sqlite_warehouse: Engine):
 )
 def test_relational_db_extract_transform(sql: str, is_valid: bool):
     """Test SQL validation in validate_extract_transform."""
-    location = RelationalDBLocation(uri="postgresql://host:1234/db2")
+    location = RelationalDBLocation(name="dbname")
 
     if is_valid:
         assert location.validate_extract_transform(sql)
@@ -234,7 +120,7 @@ def test_relational_db_execute(sqlite_warehouse: Engine):
     """Test executing a query and returning results using a real SQLite database."""
     source_testkit = source_factory(engine=sqlite_warehouse)
     source_testkit.write_to_location(credentials=sqlite_warehouse, set_credentials=True)
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
+    location = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
 
     sql = select("*").from_(source_testkit.name).sql()
     batch_size = 2
@@ -263,7 +149,7 @@ def test_relational_db_execute(sqlite_warehouse: Engine):
 
 def test_relational_db_execute_invalid(sqlite_warehouse: Engine):
     """Test that invalid queries are handled correctly when executing."""
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
+    location = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
 
     # Invalid SQL query
     sql = "SELECT * FROM nonexistent_table"
@@ -273,24 +159,11 @@ def test_relational_db_execute_invalid(sqlite_warehouse: Engine):
         list(location.execute(sql, batch_size=10))
 
 
-def test_relational_db_from_engine(sqlite_warehouse: Engine):
-    """Test creating a RelationalDBLocation from an engine."""
-    # Create a location from the engine
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
-
-    # Check that it was created correctly
-    assert location.credentials == sqlite_warehouse
-    assert location.type == "rdbms"
-
-    # Verify it works by connecting
-    assert location.connect() is True
-
-
 def test_relational_db_retrieval_and_transformation(sqlite_warehouse: Engine):
     """Test a more complete workflow with data retrieval and transformation."""
     source_testkit = source_factory(engine=sqlite_warehouse)
     source_testkit.write_to_location(credentials=sqlite_warehouse, set_credentials=True)
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
+    location = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
 
     # Execute a query with transformation
     sql = (
@@ -318,7 +191,7 @@ def test_relational_db_retrieval_and_transformation(sqlite_warehouse: Engine):
 def test_source_init():
     """Test basic SourceConfig instantiation with a Location object."""
     # Create a basic location
-    location = RelationalDBLocation(uri="sqlite:///:memory:")
+    location = RelationalDBLocation(name="sqlite")
 
     # Create index_fields
     key_field = SourceField(name="key", type=DataTypes.STRING)
@@ -349,7 +222,7 @@ def test_source_init():
 def test_source_model_validation():
     """Test that SourceConfig validation works for index_fields and key_field."""
     # Create a basic location
-    location = RelationalDBLocation(uri="sqlite:///:memory:")
+    location = RelationalDBLocation(name="sqlite")
 
     # Test key_field in index_fields validation
     key_field = SourceField(name="key", type=DataTypes.STRING)
@@ -370,7 +243,7 @@ def test_source_model_validation():
 def test_source_identifier_validation():
     """Test that key_field validation requires a string type."""
     # Create a basic location
-    location = RelationalDBLocation(uri="sqlite:///:memory:")
+    location = RelationalDBLocation(name="sqlite")
     index_fields = (SourceField(name="name", type=DataTypes.STRING),)
 
     # Valid case: String key_field
@@ -408,7 +281,7 @@ def test_source_from_new(sqlite_warehouse: Engine):
     )
     source_testkit.write_to_location(credentials=sqlite_warehouse, set_credentials=True)
 
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
+    location = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
     source = SourceConfig.new(
         location=location,
         name="test_source",
@@ -440,7 +313,7 @@ def test_source_from_new_errors(sqlite_warehouse: Engine):
     )
     source_testkit.write_to_location(credentials=sqlite_warehouse, set_credentials=True)
 
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
+    location = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
 
     with pytest.raises(ValueError):
         SourceConfig.new(
@@ -471,7 +344,7 @@ def test_source_sampling_preserves_original_sql(sqlite_warehouse: Engine):
     )
     source_testkit.write_to_location(credentials=sqlite_warehouse, set_credentials=True)
 
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
+    location = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
 
     # Use SQLite's INSTR function (returns position of substring)
     # Other databases use CHARINDEX, POSITION, etc.
@@ -516,7 +389,7 @@ def test_source_query(sqlite_warehouse: Engine):
     source_testkit.write_to_location(credentials=sqlite_warehouse, set_credentials=True)
 
     # Create location and source
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
+    location = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
     source = SourceConfig(
         location=location,
         name="test_source",
@@ -560,7 +433,7 @@ def test_source_query_name_qualification(
     """Test that column names are qualified when requested."""
     # Mock the location execute method to verify parameters
     mock_execute.return_value = (x for x in [None])  # execute needs to be a generator
-    location = RelationalDBLocation(uri=str(sqlite_warehouse.url))
+    location = RelationalDBLocation(name="sqlite")
 
     # Create source
     source = SourceConfig(
@@ -602,14 +475,13 @@ def test_source_query_name_qualification(
 @patch("matchbox.common.sources.RelationalDBLocation.execute")
 def test_source_query_batching(
     mock_execute: Mock,
-    sqlite_warehouse: Engine,
     batch_size: int,
     expected_call_kwargs: dict,
 ):
     """Test query with batching options."""
     # Mock the location execute method to verify parameters
     mock_execute.return_value = (x for x in [None])  # execute needs to be a generator
-    location = RelationalDBLocation(uri=str(sqlite_warehouse.url))
+    location = RelationalDBLocation(name="sqlite")
 
     # Create source
     source = SourceConfig(
@@ -655,7 +527,7 @@ def test_source_hash_data(sqlite_warehouse: Engine, batch_size: int):
     source_testkit.write_to_location(credentials=sqlite_warehouse, set_credentials=True)
 
     # Create location and source
-    location = RelationalDBLocation.from_engine(sqlite_warehouse)
+    location = RelationalDBLocation(name="dbname", credentials=sqlite_warehouse)
     source = SourceConfig(
         location=location,
         name="test_source",
@@ -684,7 +556,7 @@ def test_source_hash_data(sqlite_warehouse: Engine, batch_size: int):
 def test_source_hash_data_null_identifier(mock_query: Mock, sqlite_warehouse: Engine):
     """Test hash_data raises an error when source primary keys contain nulls."""
     # Create a source
-    location = RelationalDBLocation(uri=str(sqlite_warehouse.url))
+    location = RelationalDBLocation(name="sqlite")
     source = SourceConfig(
         location=location,
         name="test_source",

--- a/test/e2e/test_e2e_dag.py
+++ b/test/e2e/test_e2e_dag.py
@@ -120,7 +120,7 @@ class TestE2EPipelineBuilder:
         """
 
         # === SETUP PHASE ===
-        dw_loc = RelationalDBLocation.from_engine(self.warehouse_engine)
+        dw_loc = RelationalDBLocation(name="dbname", credentials=self.warehouse_engine)
         batch_size = 1000
 
         # Create source configs

--- a/test/e2e/test_e2e_evaluation.py
+++ b/test/e2e/test_e2e_evaluation.py
@@ -85,7 +85,7 @@ class TestE2EModelEvaluation:
         assert response.status_code == 200, "Failed to clear matchbox database"
 
         # Create DAG
-        dw_loc = RelationalDBLocation.from_engine(postgres_warehouse)
+        dw_loc = RelationalDBLocation(name="dbname", credentials=postgres_warehouse)
         batch_size = 1000
 
         source_a_config = SourceConfig.new(

--- a/test/server/postgresql/test_pg_sql.py
+++ b/test/server/postgresql/test_pg_sql.py
@@ -207,14 +207,14 @@ def populated_postgres_db(
                 source_config_id=11,
                 resolution_id=1,
                 location_type="test",
-                location_uri="test://source_a",
+                location_name="db1",
                 extract_transform="identity",
             ),
             SourceConfigs(
                 source_config_id=22,
                 resolution_id=2,
                 location_type="test",
-                location_uri="test://source_b",
+                location_name="db2",
                 extract_transform="identity",
             ),
         ]

--- a/test/server/test_adapter.py
+++ b/test/server/test_adapter.py
@@ -518,15 +518,15 @@ class TestMatchboxBackend:
             assert self.backend.source_resolutions.count() == 1
 
     def test_index_same_resolution(self):
-        """Test that indexing same-name sources in different warehouses works."""
+        """Test that indexing same-name sources in different locations works."""
         with self.scenario(self.backend, "bare") as dag:
             crn_testkit: SourceTestkit = dag.sources.get("crn")
 
             crn_source_1 = crn_testkit.source_config.model_copy(
-                update={"location": RelationalDBLocation(uri="postgres://")}
+                update={"location": RelationalDBLocation(name="postgres")}
             )
             crn_source_2 = crn_testkit.source_config.model_copy(
-                deep=True, update={"location": RelationalDBLocation(uri="mongodb://")}
+                deep=True, update={"location": RelationalDBLocation(name="mongodb")}
             )
 
             self.backend.index(crn_source_1, crn_testkit.data_hashes)

--- a/uv.lock
+++ b/uv.lock
@@ -1449,7 +1449,6 @@ dev = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "moto", extra = ["s3"] },
     { name = "pre-commit" },
-    { name = "psycopg2" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1508,7 +1507,6 @@ dev = [
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.26" },
     { name = "pre-commit", specifier = ">=3.8.0" },
-    { name = "psycopg2", specifier = ">=2.9.10" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", specifier = ">=0.25.2" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -2170,19 +2168,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/13/1e7850bb2c69a63267c3dbf37387d3f71a00fd0e2fa55c5db14d64ba1af4/psycopg_pool-3.2.6.tar.gz", hash = "sha256:0f92a7817719517212fbfe2fd58b8c35c1850cdd2a80d36b581ba2085d9148e5", size = 29770 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/fd/4feb52a55c1a4bd748f2acaed1903ab54a723c47f6d0242780f4d97104d4/psycopg_pool-3.2.6-py3-none-any.whl", hash = "sha256:5887318a9f6af906d041a0b1dc1c60f8f0dda8340c2572b74e10907b51ed5da7", size = 38252 },
-]
-
-[[package]]
-name = "psycopg2"
-version = "2.9.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/51/2007ea29e605957a17ac6357115d0c1a1b60c8c984951c19419b3474cdfd/psycopg2-2.9.10.tar.gz", hash = "sha256:12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11", size = 385672 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/a2/c51ca3e667c34e7852157b665e3d49418e68182081060231d514dd823225/psycopg2-2.9.10-cp311-cp311-win32.whl", hash = "sha256:47c4f9875125344f4c2b870e41b6aad585901318068acd01de93f3677a6522c2", size = 1024538 },
-    { url = "https://files.pythonhosted.org/packages/33/39/5a9a229bb5414abeb86e33b8fc8143ab0aecce5a7f698a53e31367d30caa/psycopg2-2.9.10-cp311-cp311-win_amd64.whl", hash = "sha256:0435034157049f6846e95103bd8f5a668788dd913a7c30162ca9503fdf542cb4", size = 1163736 },
-    { url = "https://files.pythonhosted.org/packages/3d/16/4623fad6076448df21c1a870c93a9774ad8a7b4dd1660223b59082dd8fec/psycopg2-2.9.10-cp312-cp312-win32.whl", hash = "sha256:65a63d7ab0e067e2cdb3cf266de39663203d38d6a8ed97f5ca0cb315c73fe067", size = 1025113 },
-    { url = "https://files.pythonhosted.org/packages/66/de/baed128ae0fc07460d9399d82e631ea31a1f171c0c4ae18f9808ac6759e3/psycopg2-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:4a579d6243da40a7b3182e0430493dbd55950c493d8c68f4eec0b302f6bbf20e", size = 1163951 },
-    { url = "https://files.pythonhosted.org/packages/ae/49/a6cfc94a9c483b1fa401fbcb23aca7892f60c7269c5ffa2ac408364f80dc/psycopg2-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:91fd603a2155da8d0cfcdbf8ab24a2d54bca72795b90d2a3ed2b6da8d979dee2", size = 2569060 },
 ]
 
 [[package]]


### PR DESCRIPTION
Our production set-up challenged a core assumption of the location system: one location has exactly one URI (and vice versa), by which it's defined. In reality:

* One location can have multiple URIs (as it happened to us in production across different environments)
* Multiple URIs (e.g. `sqlite:///:memory:`) can map to different locations

## 🛠️ Changes proposed in this pull request

* Use location names, instead of URIs, to identify locations on the server, and for client to filter sources by location
* No validation is performed of the credentials added to a location. It's up to the user to ensure they set up the right credentials for a location. This means they could accidentally re-index a source from the wrong warehouse, or try to query a source and be unable to do so
* Allow using different credentials for different locations when downloading samples from server

## 👀 Guidance to review
### Normalisation
I didn't create a separate table for locations, in the spirit of "smallest, simplest solution to the problem". I'm not 100% sure this is right. One one hand, if we want to set rules on the creation of locations e.g. only for admins via CLI, that's when we should handle this, and at that point we might add a description with e.g. instructions / snippets for that location. On the other hand, it might mean a slightly more complex migration then to move existing data to a new table.

### Credentials
Now that locations don't have URIs, I'm not sure that "credentials" is the right name anymore for what we're passing. We're actually passing the engine that tells it where to look. Unfortunately "engine" might not be the right word either, depending on the type of location. Arango uses the words "clients" and "db" for different layers:

```python
from arango import ArangoClient
ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="passwd")
```

And S3 uses "client":

```python
boto3.client(
    's3',
    aws_access_key_id=ACCESS_KEY,
    aws_secret_access_key=SECRET_KEY,
    aws_session_token=SESSION_TOKEN
)
```

So maybe "client" is the right word. Thoughts?

## 🤖 AI declaration

AI only used to suggest `server_default` approach in migration.

## 🔗 Relevant links

* <!-- List any useful links] -->

## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [ ] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
