### PR TITLE
bugfix: add dd_version docker label

### DIFF
--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -10,7 +10,10 @@ WORKDIR /code
 ARG MB_VERSION
 RUN if [ -z "$MB_VERSION" ]; then echo 'Environment variable MB_VERSION must be specified. Exiting.'; exit 1; fi
 ENV MB_VERSION=${MB_VERSION}
+
+# Datadog
 ENV DD_VERSION=${MB_VERSION}
+LABEL com.datadoghq.tags.version=${MB_VERSION}
 
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

Follow-up to MR https://github.com/uktrade/matchbox/pull/227 that set environment variable for dd_version but not the docker label, which I realised is also expected (see docs here https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=docker#configuration-1)


## 👀 Guidance to review

Check the docs linked.


## 🤖 AI declaration

None.


## 🔗 Relevant links

Datadog docs https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=docker#configuration-1
 
## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
