### PR TITLE
Removes breaking drop from source data inspection

### DIFF
--- a/src/matchbox/client/results.py
+++ b/src/matchbox/client/results.py
@@ -126,14 +126,12 @@ class Results(BaseModel):
                 left_on=left_merge_col,
                 right_on=left_key,
             )
-            .drop(left_key)
             .join(
                 right_data,
                 how="left",
                 left_on=right_merge_col,
                 right_on=right_key,
             )
-            .drop(right_key)
         )
 
     def probabilities_to_polars(self) -> pl.DataFrame:


### PR DESCRIPTION
`Results._merge_with_source_data()` didn't work because the left-joined column is dropped by default in polars, it seems.

## 🛠️ Changes proposed in this pull request

* Removes the drops

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## 🔗 Relevant links

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
