### PR TITLE
Add risk register to docs

### DIFF
--- a/docs/server/risks.md
+++ b/docs/server/risks.md
@@ -1,0 +1,58 @@
+This page contains a list of known data and security caveats determined by the current implementation of Matchbox.
+
+## Sensitive data sources
+
+!!! danger
+    Matchbox allows **any user** to view all identifier values in an indexed dataset. There is no authorisation model for reading data. Anyone can query any source.
+
+This is fine for many sources, because the only data stored by Matchbox are
+
+### What's usually safe
+
+Matchbox only stores:
+
+* Cryptographically secure hashes of the original data
+* Key fields (often not sensitive)
+
+For example, a dataset of tax records may contain sensitive information, but since all businesses have tax records, the presence of a business in the dataset isn’t necessarily sensitive.
+
+### What's risky
+
+Problems arise when:
+
+* A user accesses a source that maps identifiable data (like names and addresses) to secret identifiers from another source that shouldn't be revealed.
+* Which identities appear in an indexed source is sensitive information in itself.
+
+**Example:** Imagine a table of high-profile individuals under investigation. Matchbox doesn’t store investigation details, but it does expose identifiers (like passport numbers). If another source links those identifiers to names, Matchbox could be used to reveal identities.
+
+
+!!! tip
+    Do not use Matchbox to index sources where the key fields are sensitive data.
+
+Future versions of Matchbox will address this limitation by introducing an authorisation mechanism.
+
+## Table metadata
+
+!!! danger
+    Matchbox allows any user see the **list of fields** and extract-transform logic of an indexed source.
+
+!!! tip
+    Avoid indexing sources where the **field names** or **structure** are considered sensitive.
+
+## Extract-transform logic
+
+!!! danger
+    **Malicious queries** could be embedded in source configs.
+
+**Example**:
+
+* A source from RelationalDBLocation stores SQL queries used during indexing.
+* If an automated pipeline reuses these queries, a malicious user could inject harmful SQL (e.g., DROP DATABASE).
+
+Matchbox performs **basic validation**, but **cannot guarantee query safety**.
+
+
+
+!!! tip
+    Ensure that clients running extract-transform logic stored on the server have **limited permissions**.
+

--- a/docs/server/risks.md
+++ b/docs/server/risks.md
@@ -5,14 +5,12 @@ This page contains a list of known data and security caveats determined by the c
 !!! danger
     Matchbox allows **any user** to view all identifier values in an indexed dataset. There is no authorisation model for reading data. Anyone can query any source.
 
-This is fine for many sources, because the only data stored by Matchbox are
-
 ### What's usually safe
 
 Matchbox only stores:
 
 * Cryptographically secure hashes of the original data
-* Key fields (often not sensitive)
+* Key fields, which is usually a standard identifier (often not sensitive)
 
 For example, a dataset of tax records may contain sensitive information, but since all businesses have tax records, the presence of a business in the dataset isn’t necessarily sensitive.
 

--- a/docs/server/risks.md
+++ b/docs/server/risks.md
@@ -10,7 +10,7 @@ This page contains a list of known data and security caveats determined by the c
 Matchbox only stores:
 
 * Cryptographically secure hashes of the original data
-* Key fields, which is usually a standard identifier (often not sensitive)
+* Key fields, which is usually a standard identifier for your organisation (often not sensitive)
 
 For example, a dataset of tax records may contain sensitive information, but since all businesses have tax records, the presence of a business in the dataset isn’t necessarily sensitive.
 
@@ -21,8 +21,7 @@ Problems arise when:
 * A user accesses a source that maps identifiable data (like names and addresses) to secret identifiers from another source that shouldn't be revealed.
 * Which identities appear in an indexed source is sensitive information in itself.
 
-**Example:** Imagine a table of high-profile individuals under investigation. Matchbox doesn’t store investigation details, but it does expose identifiers (like passport numbers). If another source links those identifiers to names, Matchbox could be used to reveal identities.
-
+**Example:** Imagine a table of high-profile individuals under investigation. Matchbox doesn’t store investigation details, but it does expose the identifiers you use as key fields (e.g.: passport numbers). If another source links those keys to names, Matchbox could be used to reveal identities.
 
 !!! tip
     Do not use Matchbox to index sources where the key fields are sensitive data.
@@ -49,8 +48,6 @@ Future versions of Matchbox will address this limitation by introducing an autho
 
 Matchbox performs **basic validation**, but **cannot guarantee query safety**.
 
-
-
 !!! tip
-    Ensure that clients running extract-transform logic stored on the server have **limited permissions**.
+    Ensure that clients running extract-transform logic stored on the server have the least priviliges required to run legitimate queries.
 

--- a/docs/server/risks.md
+++ b/docs/server/risks.md
@@ -43,8 +43,8 @@ Future versions of Matchbox will address this limitation by introducing an autho
 
 **Example**:
 
-* A source from RelationalDBLocation stores SQL queries used during indexing.
-* If an automated pipeline reuses these queries, a malicious user could inject harmful SQL (e.g., DROP DATABASE).
+* A source from `RelationalDBLocation` stores SQL queries used during indexing.
+* If an automated pipeline reuses these queries, a malicious user could inject harmful SQL (e.g., `DROP DATABASE`).
 
 Matchbox performs **basic validation**, but **cannot guarantee query safety**.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
   - Matchbox concepts: server/concepts.md
   - Installation: server/install.md
   - Deploy: server/deploy.md
+  - Data and security risks: server/risks.md
   - API: 
     - Overview: api/server/index.md
 - API reference:


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

* Transfer internal risk register to public docs

## 👀 Guidance to review

None.

## 🤖 AI declaration

Fed it my draft, made it simpler to read, I reviewed.

## 🔗 Relevant links

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- I've updated all relevant documentation (select all that apply)
    - [x] Tutorials
