### PR TITLE
Improve concurrency model

### DIFF
--- a/src/matchbox/server/api/arrow.py
+++ b/src/matchbox/server/api/arrow.py
@@ -16,7 +16,7 @@ else:
     S3Client = Any
 
 
-async def table_to_s3(
+def table_to_s3(
     client: S3Client,
     bucket: str,
     key: str,
@@ -50,7 +50,7 @@ async def table_to_s3(
                 )
             )
 
-        await file.seek(0)
+        file.file.seek(0)
 
         client.put_object(Bucket=bucket, Key=key, Body=file.file)
 

--- a/src/matchbox/server/api/main.py
+++ b/src/matchbox/server/api/main.py
@@ -90,7 +90,7 @@ async def healthcheck() -> OKMessage:
 @app.post(
     "/login",
 )
-async def login(
+def login(
     backend: BackendDependency,
     credentials: LoginAttempt,
 ) -> LoginResult:
@@ -106,7 +106,7 @@ async def login(
     status_code=status.HTTP_202_ACCEPTED,
     dependencies=[Depends(validate_api_key)],
 )
-async def upload_file(
+def upload_file(
     background_tasks: BackgroundTasks,
     backend: BackendDependency,
     metadata_store: MetadataStoreDependency,
@@ -152,7 +152,7 @@ async def upload_file(
     key = f"{upload_id}.parquet"
 
     try:
-        await table_to_s3(
+        table_to_s3(
             client=client,
             bucket=bucket,
             key=key,
@@ -197,7 +197,7 @@ async def upload_file(
     },
     status_code=status.HTTP_200_OK,
 )
-async def get_upload_status(
+def get_upload_status(
     metadata_store: MetadataStoreDependency,
     upload_id: str,
 ) -> UploadStatus:
@@ -312,13 +312,13 @@ def match(
 
 
 @app.get("/report/resolutions")
-async def get_resolutions(backend: BackendDependency) -> ResolutionGraph:
+def get_resolutions(backend: BackendDependency) -> ResolutionGraph:
     """Get the resolution graph."""
     return backend.get_resolution_graph()
 
 
 @app.get("/database/count")
-async def count_backend_items(
+def count_backend_items(
     backend: BackendDependency,
     entity: BackendCountableType | None = None,
 ) -> CountResult:
@@ -339,7 +339,7 @@ async def count_backend_items(
     responses={409: {"model": str}},
     dependencies=[Depends(validate_api_key)],
 )
-async def clear_database(
+def clear_database(
     backend: BackendDependency,
     certain: Annotated[
         bool,

--- a/src/matchbox/server/api/routers/eval.py
+++ b/src/matchbox/server/api/routers/eval.py
@@ -36,7 +36,7 @@ router = APIRouter(prefix="/eval", tags=["eval"])
     responses={404: {"model": NotFoundError}},
     status_code=status.HTTP_201_CREATED,
 )
-async def insert_judgement(
+def insert_judgement(
     backend: BackendDependency,
     judgement: Judgement,
 ):
@@ -63,7 +63,7 @@ async def insert_judgement(
 @router.get(
     "/judgements",
 )
-async def get_judgements(backend: BackendDependency) -> ParquetResponse:
+def get_judgements(backend: BackendDependency) -> ParquetResponse:
     """Retrieve all judgements from human evaluators."""
     judgements, expansion = backend.get_judgements()
     judgements_buffer, expansion_buffer = (
@@ -85,7 +85,7 @@ async def get_judgements(backend: BackendDependency) -> ParquetResponse:
     "/compare",
     responses={404: {"model": NotFoundError}},
 )
-async def compare_models(
+def compare_models(
     backend: BackendDependency,
     resolutions: Annotated[
         list[ModelResolutionName],
@@ -115,7 +115,7 @@ async def compare_models(
     "/samples",
     responses={404: {"model": NotFoundError}, 422: {"model": InvalidParameterError}},
 )
-async def sample(
+def sample(
     backend: BackendDependency, n: int, resolution: ModelResolutionName, user_id: int
 ) -> ParquetResponse:
     """Sample n cluster to validate."""

--- a/src/matchbox/server/api/routers/models.py
+++ b/src/matchbox/server/api/routers/models.py
@@ -45,7 +45,7 @@ router = APIRouter(prefix="/models", tags=["models"])
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(validate_api_key)],
 )
-async def insert_model(
+def insert_model(
     backend: BackendDependency, model: ModelConfig
 ) -> ResolutionOperationStatus:
     """Insert a model into the backend."""
@@ -72,9 +72,7 @@ async def insert_model(
     "/{name}",
     responses={404: {"model": NotFoundError}},
 )
-async def get_model(
-    backend: BackendDependency, name: ModelResolutionName
-) -> ModelConfig:
+def get_model(backend: BackendDependency, name: ModelResolutionName) -> ModelConfig:
     """Get a model from the backend."""
     try:
         return backend.get_model(name=name)
@@ -93,7 +91,7 @@ async def get_model(
     status_code=status.HTTP_202_ACCEPTED,
     dependencies=[Depends(validate_api_key)],
 )
-async def set_results(
+def set_results(
     backend: BackendDependency,
     metadata_store: MetadataStoreDependency,
     name: ModelResolutionName,
@@ -117,7 +115,7 @@ async def set_results(
     "/{name}/results",
     responses={404: {"model": NotFoundError}},
 )
-async def get_results(
+def get_results(
     backend: BackendDependency, name: ModelResolutionName
 ) -> ParquetResponse:
     """Download results for a model as a parquet file."""
@@ -146,7 +144,7 @@ async def get_results(
     },
     dependencies=[Depends(validate_api_key)],
 )
-async def set_truth(
+def set_truth(
     backend: BackendDependency,
     name: ModelResolutionName,
     truth: Annotated[int, Body(ge=0, le=100)],
@@ -182,7 +180,7 @@ async def set_truth(
     "/{name}/truth",
     responses={404: {"model": NotFoundError}},
 )
-async def get_truth(backend: BackendDependency, name: ModelResolutionName) -> float:
+def get_truth(backend: BackendDependency, name: ModelResolutionName) -> float:
     """Get truth data for a model."""
     try:
         return backend.get_model_truth(name=name)
@@ -199,7 +197,7 @@ async def get_truth(backend: BackendDependency, name: ModelResolutionName) -> fl
     "/{name}/ancestors",
     responses={404: {"model": NotFoundError}},
 )
-async def get_ancestors(
+def get_ancestors(
     backend: BackendDependency, name: ModelResolutionName
 ) -> list[ModelAncestor]:
     """Get the ancestors for a model."""
@@ -225,7 +223,7 @@ async def get_ancestors(
     },
     dependencies=[Depends(validate_api_key)],
 )
-async def set_ancestors_cache(
+def set_ancestors_cache(
     backend: BackendDependency,
     name: ModelResolutionName,
     ancestors: list[ModelAncestor],
@@ -261,7 +259,7 @@ async def set_ancestors_cache(
     "/{name}/ancestors_cache",
     responses={404: {"model": NotFoundError}},
 )
-async def get_ancestors_cache(
+def get_ancestors_cache(
     backend: BackendDependency, name: ModelResolutionName
 ) -> list[ModelAncestor]:
     """Get the cached ancestors for a model."""

--- a/src/matchbox/server/api/routers/resolutions.py
+++ b/src/matchbox/server/api/routers/resolutions.py
@@ -34,7 +34,7 @@ router = APIRouter(prefix="/resolutions", tags=["resolutions"])
     },
     dependencies=[Depends(validate_api_key)],
 )
-async def delete_resolution(
+def delete_resolution(
     backend: BackendDependency,
     name: ResolutionName,
     certain: Annotated[

--- a/src/matchbox/server/api/routers/sources.py
+++ b/src/matchbox/server/api/routers/sources.py
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/sources", tags=["sources"])
     status_code=status.HTTP_202_ACCEPTED,
     dependencies=[Depends(validate_api_key)],
 )
-async def add_source(
+def add_source(
     metadata_store: MetadataStoreDependency, source: SourceConfig
 ) -> UploadStatus:
     """Create an upload and insert task for indexed source data."""
@@ -44,7 +44,7 @@ async def add_source(
     "/{name}",
     responses={404: {"model": NotFoundError}},
 )
-async def get_source_config(
+def get_source_config(
     backend: BackendDependency,
     name: SourceResolutionName,
 ) -> SourceConfig:
@@ -64,7 +64,7 @@ async def get_source_config(
     "",
     responses={404: {"model": NotFoundError}},
 )
-async def get_resolution_source_configs(
+def get_resolution_source_configs(
     backend: BackendDependency,
     name: ResolutionName,
 ) -> list[SourceConfig]:

--- a/test/server/api/routes/test_routes_models.py
+++ b/test/server/api/routes/test_routes_models.py
@@ -1,4 +1,4 @@
-import asyncio
+from time import sleep
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, patch
 
@@ -146,9 +146,8 @@ def test_model_upload(
     mock_add_task.assert_called_once()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("model_type", ["deduper", "linker"])
-async def test_complete_model_upload_process(
+def test_complete_model_upload_process(
     s3: S3Client, model_type: str, test_client: TestClient
 ):
     """Test the complete upload process for models from creation through processing."""
@@ -215,7 +214,7 @@ async def test_complete_model_upload_process(
         elif status == "failed":
             pytest.fail(f"Upload failed: {response.json().get('details')}")
         elif status in ["processing", "queued"]:
-            await asyncio.sleep(0.1)  # Small delay between polls
+            sleep(0.1)  # Small delay between polls
         else:
             pytest.fail(f"Unexpected status: {status}")
 

--- a/test/server/api/routes/test_routes_sources.py
+++ b/test/server/api/routes/test_routes_sources.py
@@ -1,4 +1,4 @@
-import asyncio
+from time import sleep
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
@@ -106,8 +106,7 @@ def test_add_source(test_client: TestClient):
     mock_backend.index.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_complete_source_upload_process(s3: S3Client, test_client: TestClient):
+def test_complete_source_upload_process(s3: S3Client, test_client: TestClient):
     """Test the complete upload process from source creation through processing."""
     # Setup the backend
     mock_backend = Mock()
@@ -162,7 +161,7 @@ async def test_complete_source_upload_process(s3: S3Client, test_client: TestCli
         elif status == "failed":
             pytest.fail(f"Upload failed: {response.json().get('details')}")
         elif status in ["processing", "queued"]:
-            await asyncio.sleep(0.1)  # Small delay between polls
+            sleep(0.1)  # Small delay between polls
         else:
             pytest.fail(f"Unexpected status: {status}")
 

--- a/test/server/api/test_utilities.py
+++ b/test/server/api/test_utilities.py
@@ -21,8 +21,7 @@ else:
     S3Client = Any
 
 
-@pytest.mark.asyncio
-async def test_file_to_s3(s3: S3Client):
+def test_file_to_s3(s3: S3Client):
     """Test that a file can be uploaded to S3."""
     # Create a mock bucket
     s3.create_bucket(
@@ -59,7 +58,7 @@ async def test_file_to_s3(s3: S3Client):
 
     # Call the function
     key = "foo.parquet"
-    upload_id = await table_to_s3(
+    upload_id = table_to_s3(
         client=s3,
         bucket="test-bucket",
         key=key,
@@ -84,7 +83,7 @@ async def test_file_to_s3(s3: S3Client):
     text_file = UploadFile(filename="test.txt", file=BytesIO(b"test"))
 
     with pytest.raises(MatchboxServerFileError):
-        await table_to_s3(
+        table_to_s3(
             client=s3,
             bucket="test-bucket",
             key=key,
@@ -95,7 +94,7 @@ async def test_file_to_s3(s3: S3Client):
     # Test 3: Upload a parquet file with a different schema
     corrupted_schema = table.schema.remove(0)
     with pytest.raises(MatchboxServerFileError):
-        await table_to_s3(
+        table_to_s3(
             client=s3,
             bucket="test-bucket",
             key=key,


### PR DESCRIPTION
<!-- Give high level context to this PR -->

## 🛠️ Changes proposed in this pull request

* Turn all routes interacting with S3 or Postgres to use sync functions
  * Also affects some functions on which those routes depend
* 

## 👀 Guidance to review

* I've kept the health-check endpoints and FastAPI dependencies async, see relevant links for details
  * Key quote is "If your application (somehow) doesn't have to communicate with anything else and wait for it to respond, use async def, even if you don't need to use await inside."

## 🤖 AI declaration

<!-- Declare code where AI was used, and how you ensured its quality -->

## 🔗 Relevant links

* FastAPI docs: [using files in synchronous context](https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile)
* FastAPI docs: https://fastapi.tiangolo.com/async/

## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [ ] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
