### PR TITLE
Added index to ORM

### DIFF
--- a/src/matchbox/common/eval.py
+++ b/src/matchbox/common/eval.py
@@ -177,7 +177,11 @@ def process_judgements(
         # if missing expansion, assume we're dealing with singleton leaves
         .with_columns(
             pl.when(pl.col("endorsed_leaves").is_null())
-            .then(pl.col("endorsed").map_elements(lambda x: [x]))
+            .then(
+                pl.col("endorsed").map_elements(
+                    lambda x: [x], return_dtype=pl.List(pl.UInt64)
+                )
+            )
             .otherwise(pl.col("endorsed_leaves"))
             .alias("endorsed_leaves")
         )

--- a/src/matchbox/server/postgresql/alembic.ini
+++ b/src/matchbox/server/postgresql/alembic.ini
@@ -2,7 +2,7 @@
 script_location = src/matchbox/server/postgresql/alembic
 prepend_sys_path = .
 version_locations = src/matchbox/server/postgresql/alembic/versions
-version_path_separator = os
+path_separator = os
 revision_environment = true
 
 [loggers]

--- a/src/matchbox/server/postgresql/alembic/versions/b38d61ab11cc_add_index_to_the_clustersourcekey_table.py
+++ b/src/matchbox/server/postgresql/alembic/versions/b38d61ab11cc_add_index_to_the_clustersourcekey_table.py
@@ -1,0 +1,35 @@
+"""Add index to the ClusterSourceKey table.
+
+Revision ID: b38d61ab11cc
+Revises: 7a2d1b10ac0f
+Create Date: 2025-08-21 15:21:52.224388
+
+"""
+
+from typing import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b38d61ab11cc"
+down_revision: str | None = "7a2d1b10ac0f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index(
+        "ix_cluster_keys_source_config_id",
+        "cluster_keys",
+        ["source_config_id"],
+        unique=False,
+        schema="mb",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_cluster_keys_source_config_id", table_name="cluster_keys", schema="mb"
+    )

--- a/src/matchbox/server/postgresql/orm.py
+++ b/src/matchbox/server/postgresql/orm.py
@@ -344,6 +344,7 @@ class ClusterSourceKey(CountMixin, MBDB.MatchboxBase):
     __table_args__ = (
         Index("ix_cluster_keys_cluster_id", "cluster_id"),
         Index("ix_cluster_keys_keys", "key"),
+        Index("ix_cluster_keys_source_config_id", "source_config_id"),
         UniqueConstraint("key_id", "source_config_id", name="unique_keys_source"),
     )
 

--- a/test/client/test_eval.py
+++ b/test/client/test_eval.py
@@ -163,7 +163,12 @@ def test_get_samples(
             content=table_to_buffer(just_baz_samples).read(),
         )
     )
-    no_accessible_samples = get_samples(n=10, resolution="resolution", user_id=user_id)
+    with pytest.warns(
+        UserWarning, match="Skipping baz, incompatible with given client"
+    ):
+        no_accessible_samples = get_samples(
+            n=10, resolution="resolution", user_id=user_id
+        )
     assert no_accessible_samples == {}
 
     # Using default client as fallback

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1312,7 +1313,6 @@ wheels = [
 
 [[package]]
 name = "matchbox-db"
-version = "0.4.11.dev9+g525035a2.d20250808"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1404,6 +1404,7 @@ requires-dist = [
     { name = "streamlit", marker = "extra == 'eval'", specifier = ">=1.45.0" },
     { name = "tomli", marker = "extra == 'server'", specifier = ">=2.0.1" },
 ]
+provides-extras = ["server", "eval"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Adds an index to `ClusterSourceKey` to deal with a slow probabilistic query.

## 🛠️ Changes proposed in this pull request

* Adds index to `ClusterSourceKey` to fix a slow-running probabilistic query
* Fixed several warnings
    * `map_elements` without a return type
    * Untested warning where expected in a unit test
    * `path_separator` change in Alembic config

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## 🔗 Relevant links

None.

## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
