### PR TITLE
feature: add curl as an aid to deployment healthchecks

### DIFF
--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.13-slim AS base
 
-# Install git (required for setuptools_scm)
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+# Install git (required for setuptools_scm) and curl (as an aid for healthchecks)
+RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/src/matchbox/server/Dockerfile
+++ b/src/matchbox/server/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.13-slim AS base
 
 # Install git (required for setuptools_scm) and curl (as an aid for healthchecks)
+RUN apt-get update && \
+    apt-get install -y git curl && \
+    rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1515,7 +1514,6 @@ requires-dist = [
     { name = "streamlit", marker = "extra == 'eval'", specifier = ">=1.45.0" },
     { name = "tomli", marker = "extra == 'server'", specifier = ">=2.0.1" },
 ]
-provides-extras = ["server", "eval"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

Add curl to the Docker image. The reason is this is useful for health checks when deployed. It could go in matchbox-deploy but my view is curl is sufficiently widely used for this purpose to the point that any open-source user would likely expect it to be there. 

If you agree and this is merged then I'll remove it from the version of matchbox-deploy I've got currently which goes together with adding these health checks on an MR in data-workspace (i.e. we want to make sure curl is there, either from matchbox or from matchbox-deploy, before that change would be applied to prod/staging or the health checks fail!).


## 👀 Guidance to review


## 🤖 AI declaration

None.


## 🔗 Relevant links



## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [ ] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
