### PR TITLE
Changed build trigger to be adding tags so we can release post-build

### DIFF
--- a/.github/workflows/deploy-docker-image-to-packages.yml
+++ b/.github/workflows/deploy-docker-image-to-packages.yml
@@ -3,8 +3,8 @@ name: Create and Publish the Matchbox Open-Source Docker Image
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
+    tags:
+      - "v*.*.*"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -1,8 +1,10 @@
 name: Deploy package to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    tags:
+      - "v*.*.*"
 
 jobs:
   build:

--- a/.github/workflows/docs-build-and-deploy.yml
+++ b/.github/workflows/docs-build-and-deploy.yml
@@ -1,8 +1,8 @@
 name: Documentation (build and deploy)
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*.*.*"
 
 jobs:
   build:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -113,6 +113,15 @@ We have a VSCode default debugging profile called "API debug", which allows you 
 - Change the `MB__CLIENT__API_ROOT` variable to redirect tests to use the debug port (`8080`)
 - Disable time-outs by commenting out the `MB__CLIENT__TIMEOUT` variable
 
+## Releasing
+
+We first tag the commit in main we wish to release using [semantic versioning syntax](https://semver.org) (`vX.X.X`). 
+
+Once deploy GitHub Actions are successfully run, we then draft release notes and attach them to the tag.
+
+> [!CAUTION]
+> Releasing directly can currently cause race conditions in our deployment pipeline. We hope to resolve this soon.
+
 ## Standards
 
 ### Code


### PR DESCRIPTION
We're getting a race condition in AWS CodeBuild because it builds before we've finished releasing.

The quickest fix right now is to build artefacts for a release before we trigger it from GitHub. 

## 🛠️ Changes proposed in this pull request

* Changes all GitHub Action release triggers to be on semver tags
* Adds documentation on new release procedure

## 👀 Guidance to review

Note this won't be forever. See the ticket for more info.

## 🤖 AI declaration

None.

## 🔗 Relevant links

* [Semantic versioning](https://semver.org)
* [Syntax for detecting tags](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushbranchestagsbranches-ignoretags-ignore) (note: not regex)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [x] Developer docs
