### PR TITLE
Fixed deployment bug on merges to main

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -2,7 +2,6 @@ name: Deploy package to PyPI
 
 on:
   push:
-    branches: [main]
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/docs-build-and-deploy.yml
+++ b/.github/workflows/docs-build-and-deploy.yml
@@ -1,4 +1,5 @@
 name: Documentation (build and deploy)
+
 on:
   push:
     tags:


### PR DESCRIPTION
We were triggering deploy on merge to main, instead of new tag creation.

## 🛠️ Changes proposed in this pull request

Fixed the GitHub Actions.

## 👀 Guidance to review

Notice how the correctly-configured `Documentation (build and deploy)` [didn't run on the last merge to main](https://github.com/uktrade/matchbox/actions). That's because it's configured right.

Note how they match now.

## 🤖 AI declaration

None.

## 🔗 Relevant links

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [ ] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
