### PR TITLE
Fixed regex issue in release.yml.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           version="${{ github.event.inputs.version }}"
           clean_version=${version#v}
           
-          if ! echo "$clean_version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+; then
+          if ! echo "$clean_version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Error: Version must be in format x.x.x"
             exit 1
           fi


### PR DESCRIPTION
Deploy failed:

```
Run version="v0.5.6"
  version="v0.5.6"
  clean_version=${version#v}
  
  if ! echo "$clean_version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+; then
    echo "Error: Version must be in format x.x.x"
    exit 1
  fi
  
  final_tag="v$clean_version"
  echo "tag=$final_tag" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
  env:
    REGISTRY: ghcr.io
    IMAGE_NAME: uktrade/matchbox
/home/runner/work/_temp/81ebdde3-5b15-4ce5-99d0-a0ea5c1c185b.sh: line 4: unexpected EOF while looking for matching `''
Error: Process completed with exit code 2.
```

## 🛠️ Changes proposed in this pull request

Fixes regex.

## 👀 Guidance to review

New code works:

```
willlangdale@DIT004003 matchbox % version="v0.5.6" && clean_version=${version#v} && if echo "$clean_version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' >/dev/null; then echo "✅ WORKS: $clean_version is valid"; else echo "❌ BROKEN: $clean_version is invalid"; fi
✅ WORKS: 0.5.6 is valid
```

## 🤖 AI declaration

100% AI written, hand tested.

## 🔗 Relevant links

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [ ] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
