### PR TITLE
Moves merges to main to creating a prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-push-development-image:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
       attestations: write
       id-token: write
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with: 
+          python-version: "3.11"
 
       - name: Extract development version
         run: echo "MB_VERSION=$(uv run --frozen python -m setuptools_scm)" >> $GITHUB_ENV
@@ -53,3 +55,17 @@ jobs:
           build-args: |
             MB_VERSION=${{ env.MB_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Create development prerelease
+        uses: ncipollo/release-action@v1
+        with:
+          tag: development
+          name: Development
+          prerelease: true
+          body: |
+            This is an automated development build from the latest main branch. 
+            Contains the most recent changes and may be unstable.
+            
+            **Version:** ${{ env.MB_VERSION }}
+            **Commit:** ${{ github.sha }}
+          allowUpdates: true


### PR DESCRIPTION
We're still getting race conditions, this time in staging.

This can be avoided by triggering CodeBuild on a prerelease, which I've created PRs for:

* [data-workspace#526](https://github.com/uktrade/data-workspace/pull/526)
* [data-workspace-deploy#151](https://github.com/uktrade/data-workspace-deploy/pull/151).

## 🛠️ Changes proposed in this pull request

Changes the prerelease action to trigger on merges to main, build and publish the development image, then create a development prerelease.

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## 🔗 Relevant links

* [ncipollo/release-action](https://github.com/ncipollo/release-action)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
