### PR TITLE
Broke justfile out into manageable smaller modules

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,8 @@
+# PostgreSQL migration
+mod migrate 'src/matchbox/server/postgresql/justfile'
+# Evaluation app
+mod eval 'src/matchbox/client/eval/justfile'
+
 # Build and run all containers
 build *DOCKER_ARGS:
     uv sync --extra server
@@ -37,27 +42,3 @@ test ENV="":
         just build -d
         uv run pytest
     fi
-
-# Bring the database up to the latest migration script (the head)
-migration-apply:
-    uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" upgrade head
-
-# Check if migration-generate would produce a migration script without creating one
-migration-check:
-    uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" check
-
-# Autogenerate a new migration (keep your descriptive message brief as it is appended to the filename)
-migration-generate descriptive-message:
-    uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" revision --autogenerate -m "{{descriptive-message}}"
-
-# Reset the DB to the base state
-migration-reset:
-    uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" downgrade base
-
-# Run evaluation app
-eval:
-    streamlit run src/matchbox/client/eval/ui.py
-
-# Run evaluation app with some mock data
-eval-mock:
-    uv run python src/matchbox/client/eval/mock_ui.py

--- a/src/matchbox/client/eval/justfile
+++ b/src/matchbox/client/eval/justfile
@@ -1,0 +1,9 @@
+set working-directory := "../../../.."
+
+# Run evaluation app
+default:
+    streamlit run src/matchbox/client/eval/ui.py
+
+# Run evaluation app with some mock data
+mock:
+    uv run python src/matchbox/client/eval/mock_ui.py

--- a/src/matchbox/server/postgresql/justfile
+++ b/src/matchbox/server/postgresql/justfile
@@ -1,0 +1,20 @@
+set working-directory := "../../../.."
+
+default:
+    just -f src/matchbox/server/postgresql/justfile -l
+
+# Bring the database up to the latest migration script (the head)
+apply:
+    uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" upgrade head
+
+# Check if migration-generate would produce a migration script without creating one
+check:
+    uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" check
+
+# Autogenerate a new migration (keep your descriptive message brief as it is appended to the filename)
+generate descriptive-message:
+    uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" revision --autogenerate -m "{{descriptive-message}}"
+
+# Reset the DB to the base state
+reset:
+    uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" downgrade base


### PR DESCRIPTION
The justfile is big and hard to read. Modules make it easier to use and put commands in the places they're used.

## 🛠️ Changes proposed in this pull request

* Add `just eval` commands for evaluation
* Add `just migrate` commands for migrating postgres

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## 🔗 Relevant links

* [Justfile modules](https://just.systems/man/en/modules1190.html)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
