### PR TITLE
Fixed accidental removal of latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Save Docker image
-        run: docker save ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} > ${{ runner.temp }}/docker-image.tar
+        run: |
+          # Save all tags created by the build
+          docker save ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
+            > ${{ runner.temp }}/docker-image.tar
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4
@@ -201,5 +204,5 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.build.outputs.tag }}
-          name: Release ${{ needs.build.outputs.tag }}
+          name: ${{ needs.build.outputs.tag }}
           generateReleaseNotes: true


### PR DESCRIPTION
The "latest" tag wasn't moving in release, causing the wrong thing to deploy.

## 🛠️ Changes proposed in this pull request

* Removes the accidental cherry-picking of the Docker tag, instead of using all
* Harmonises release name

## 👀 Guidance to review

Proof it works locally:

```text
(matchbox-db) DIT004003:matchbox willlangdale$ docker images ghcr.io/uktrade/matchbox
REPOSITORY                 TAG       IMAGE ID       CREATED         SIZE
ghcr.io/uktrade/matchbox   0.5.6     36ec752a6719   4 minutes ago   1.66GB
ghcr.io/uktrade/matchbox   latest    36ec752a6719   4 minutes ago   1.66GB
(matchbox-db) DIT004003:matchbox willlangdale$ docker save ghcr.io/uktrade/matchbox > /tmp/test-image.tar
(matchbox-db) DIT004003:matchbox willlangdale$ docker rmi ghcr.io/uktrade/matchbox:0.5.6 ghcr.io/uktrade/matchbox:latest || true
Untagged: ghcr.io/uktrade/matchbox:0.5.6
Untagged: ghcr.io/uktrade/matchbox:latest
Deleted: sha256:36ec752a6719d44c67aa6c7e81b54e165fc16f533c88dc22ef8485221174dd5b
(matchbox-db) DIT004003:matchbox willlangdale$ docker images ghcr.io/uktrade/matchbox
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
(matchbox-db) DIT004003:matchbox willlangdale$ docker load --input /tmp/test-image.tar
Loaded image: ghcr.io/uktrade/matchbox:0.5.6
Loaded image: ghcr.io/uktrade/matchbox:latest
(matchbox-db) DIT004003:matchbox willlangdale$ docker images ghcr.io/uktrade/matchbox
REPOSITORY                 TAG       IMAGE ID       CREATED         SIZE
ghcr.io/uktrade/matchbox   0.5.6     36ec752a6719   4 minutes ago   1.66GB
ghcr.io/uktrade/matchbox   latest    36ec752a6719   4 minutes ago   1.66GB
```

## 🤖 AI declaration

None.

## 🔗 Relevant links

* Docker `save` [documentation of this syntax](https://docs.docker.com/reference/cli/docker/image/save/#cherry-pick-particular-tags)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
