### PR TITLE
Make prerelease action more robust

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -34,7 +34,11 @@ jobs:
           python-version: "3.11"
 
       - name: Extract development version
-        run: echo "MB_VERSION=$(uv run --frozen python -m setuptools_scm)" >> $GITHUB_ENV
+        run: |
+          echo "MB_VERSION=$( \
+            SETUPTOOLS_SCM_PRETEND_METADATA='{distance=1}' \
+            uv run --frozen python -m setuptools_scm \
+          )" >> $GITHUB_ENV
 
       - name: Extract tag metadata for Docker
         id: meta
@@ -45,15 +49,11 @@ jobs:
             type=raw,value=${{ env.MB_VERSION }}
             type=raw,value=development
 
-      - name: Build and push development Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: src/matchbox/server/Dockerfile
-          push: true
-          build-args: |
-            MB_VERSION=${{ env.MB_VERSION }}
-          tags: ${{ steps.meta.outputs.tags }}
+      - name: Delete existing development release if it exists
+        run: |
+          gh release delete development --yes || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create development prerelease
         uses: ncipollo/release-action@v1
@@ -68,4 +68,3 @@ jobs:
             
             **Version:** ${{ env.MB_VERSION }}
             **Commit:** ${{ github.sha }}
-          allowUpdates: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,8 @@ default-groups = ["dev", "typing"]
 package = true
 upgrade-package = ["ruff"]
 constraint-dependencies = [
-    "urllib3>=2.5.0"
+    "urllib3>=2.5.0",
+    "setuptools-scm>=9.2.0"
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,10 @@ resolution-markers = [
 ]
 
 [manifest]
-constraints = [{ name = "urllib3", specifier = ">=2.5.0" }]
+constraints = [
+    { name = "setuptools-scm", specifier = ">=9.2.0" },
+    { name = "urllib3", specifier = ">=2.5.0" },
+]
 
 [[package]]
 name = "adbc-driver-manager"
@@ -2834,15 +2837,15 @@ wheels = [
 
 [[package]]
 name = "setuptools-scm"
-version = "8.3.1"
+version = "9.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/19/7ae64b70b2429c48c3a7a4ed36f50f94687d3bfcd0ae2f152367b6410dff/setuptools_scm-8.3.1.tar.gz", hash = "sha256:3d555e92b75dacd037d32bafdf94f97af51ea29ae8c7b234cf94b7a5bd242a63", size = 78088 }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8d/ffdcace33d0480d591057a30285b7c33f8dc431fed3fff7dbadf5f9f128f/setuptools_scm-9.2.0.tar.gz", hash = "sha256:6662c9b9497b6c9bf13bead9d7a9084756f68238302c5ed089fb4dbd29d102d7", size = 201229 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/ac/8f96ba9b4cfe3e4ea201f23f4f97165862395e9331a424ed325ae37024a8/setuptools_scm-8.3.1-py3-none-any.whl", hash = "sha256:332ca0d43791b818b841213e76b1971b7711a960761c5bea5fc5cdb5196fbce3", size = 43935 },
+    { url = "https://files.pythonhosted.org/packages/f7/14/dd3a6053325e882fe191fb4b42289bbdfabf5f44307c302903a8a3236a0a/setuptools_scm-9.2.0-py3-none-any.whl", hash = "sha256:c551ef54e2270727ee17067881c9687ca2aedf179fa5b8f3fab9e8d73bdc421f", size = 62099 },
 ]
 
 [[package]]


### PR DESCRIPTION
The prerelease webhook isn't firing on GitHub, instead firing things like `830c1ff0-93bc-11f0-973b-f7610dc1ad8b release.edited`. AWS doesn't pick this up as a prerelease.

Also, prereleasing from a tagged version messes up the tagging of that release.

## 🛠️ Changes proposed in this pull request

* Delete the prerelease in an effort to trigger the right event
* Uses `SETUPTOOLS_SCM_PRETEND_METADATA` so that
    * If you release from a tagged commit, you still get the dev tag
    * If you release from a non-tagged commit, you get the same dev tag as if you didn't use the env override

## 👀 Guidance to review

Observe:

```
(matchbox-db) DIT004003:matchbox willlangdale$ uv run --frozen python -m setuptools_scm
0.5.8.dev1+g7006f5684
(matchbox-db) DIT004003:matchbox willlangdale$ SETUPTOOLS_SCM_PRETEND_METADATA="{distance=1}" uv run --frozen python -m setuptools_scm
0.5.8.dev1+g7006f5684
```

## 🤖 AI declaration

None.

## 🔗 Relevant links

* [Setuptools CSM documentation](https://setuptools-scm.readthedocs.io/en/latest/overrides/#use-case-cicd-environments) for mocking metadata (added in 9.2)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
