### PR TITLE
Fix prerelease MB version identification

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      mb_version: ${{ steps.get_version.outputs.mb_version }}
     permissions:
       contents: write
       packages: write
@@ -36,11 +38,11 @@ jobs:
       - name: Extract development version
         id: get_version
         run: |
-          echo "version=$(uv run --frozen python -m setuptools_scm)" >> $GITHUB_OUTPUT
+          echo "mb_version=$(uv run --frozen python -m setuptools_scm)" >> "$GITHUB_OUTPUT"
 
       - name: Build package
         env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.get_version.outputs.version }}
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.get_version.outputs.mb_version }}
         run: uv build
 
       - name: Upload package artifacts
@@ -55,7 +57,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ env.MB_VERSION }}
+            type=raw,value=${{ steps.version.outputs.mb_version }}
             type=raw,value=development
 
       - name: Build and push Docker image
@@ -65,7 +67,7 @@ jobs:
           file: src/matchbox/server/Dockerfile
           push: true
           build-args: |
-            MB_VERSION=${{ steps.version.outputs.version }}
+            MB_VERSION=${{ steps.version.outputs.mb_version }}
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Delete existing development release if it exists
@@ -85,7 +87,7 @@ jobs:
             
             May be unstable.
             
-            **Version:** ${{ env.MB_VERSION }}
+            **Version:** ${{ steps.get_version.outputs.mb_version }}
             **Commit:** ${{ github.sha }}
 
   deploy-package:


### PR DESCRIPTION
Previous attempt to get pre-release to publish dev version of package to PyPi failed.

## 🛠️ Changes proposed in this pull request

* Define step output in pre-release YAML as an attempt to fix broken workflow

## 👀 Guidance to review

None

## 🤖 AI declaration

None

## 🔗 Relevant links

* [GitHub guide on passing output between steps](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
