### PR TITLE
Remove local version label from prereleased package

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Extract development version
         id: get_version
         run: |
-          echo "mb_version=$(uv run --frozen python -m setuptools_scm)" >> "$GITHUB_OUTPUT"
+          echo "mb_version=$(uv run --frozen python -m setuptools_scm | sed 's/+.*//')" \
+          >> "$GITHUB_OUTPUT"
 
       - name: Build package
         env:


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

Remove local version label from pre-release package prior to it being pushed to PyPi. For example, remove the part after the plus sign in `0.6.3.dev51+g379cee97c.d20251007`

## 👀 Guidance to review

I tried using a way native to `setuptools_scm`, but couldn't get it to work in the CLI, and decided it wasn't worth my time.

## 🤖 AI declaration

Generated the `sed` expression.

## 🔗 Relevant links

* [Example of error I was getting](https://github.com/pypi/warehouse/issues/18348)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
