### PR TITLE
Add pool management params to try and clear up zombie connections

### DIFF
--- a/src/matchbox/server/postgresql/db.py
+++ b/src/matchbox/server/postgresql/db.py
@@ -97,7 +97,13 @@ class MatchboxDatabase:
     def _connect(self):
         """Connect to the database."""
         self._engine = create_engine(
-            url=self.connection_string(), logging_name="matchbox.engine", echo=False
+            url=self.connection_string(),
+            logging_name="matchbox.engine",
+            echo=False,
+            pool_size=5,
+            max_overflow=10,
+            pool_recycle=3600,
+            pool_pre_ping=True,
         )
         self._SessionLocal = sessionmaker(
             autocommit=False, autoflush=False, bind=self._engine
@@ -115,6 +121,10 @@ class MatchboxDatabase:
         )
         self._adbc_pool = QueuePool(
             self._source_adbc_connection.adbc_clone,
+            pool_size=5,
+            max_overflow=10,
+            timeout=30,
+            recycle=3600,
         )
 
     def _disconnect_adbc(self) -> None:


### PR DESCRIPTION
The database has idle queries lasting for 60 hours. I suspect it's the `QueuePool` and have chucked in some settings to try and ameliorate the problem.

|pid|usename      |application_name|state|query_start               |state_change              |total_duration_minutes|idle_duration_minutes|query_preview                              |
|---|-------------|----------------|-----|--------------------------|--------------------------|----------------------|---------------------|-------------------------------------------|
|48197|jupyterhub_matchbox_master|                |idle |2025-10-24 18:15:38.853530|2025-10-24 18:15:38.853598|3688.6958219333333333 |NULL                 |COMMIT                                     |
|48232|jupyterhub_matchbox_master|                |idle |2025-10-24 18:15:41.002867|2025-10-24 18:15:41.010829|3688.6599996500000000 |NULL                 |COMMIT                                     |
|30474|rdsadmin     |PostgreSQL JDBC Driver|idle |2025-10-26 18:02:34.461025|2025-10-26 18:02:34.518247|821.7690303500000000  |NULL                 |Select * from aurora_scale_buffer_cache($1)|
|48226|jupyterhub_matchbox_master|                |idle |2025-10-27 02:55:51.172340|2025-10-27 02:55:51.177847|288.4905084333333333  |NULL                 |ROLLBACK                                   |
|47832|jupyterhub_matchbox_master|                |idle |2025-10-27 03:03:15.743767|2025-10-27 03:03:15.746358|281.0809846500000000  |NULL                 |ROLLBACK                                   |

## 🛠️ Changes proposed in this pull request

Adds pool recycle and pool pre ping to each queue pool. Makes pool size and max overflow explicit.

## 👀 Guidance to review

You may challenge that this is a problem at all. I don't know, but my hope is that it either:

a) Is, and this helps the problems we're currently having in the pipeline
b) Isn't, and this reduces noise when diagnosing this same issue

## 🤖 AI declaration

Ideated with AI.

## 🔗 Relevant links

* SQLAlchemy [create engine default args](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine)

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
