### PR TITLE
Added manual stat collection for PostgreSQL copy operations

### DIFF
--- a/src/matchbox/server/postgresql/alembic/env.py
+++ b/src/matchbox/server/postgresql/alembic/env.py
@@ -42,5 +42,7 @@ def run_migrations_online() -> None:
         with context.begin_transaction():
             context.run_migrations()
 
+    connectable.dispose()
+
 
 run_migrations_online()

--- a/src/matchbox/server/postgresql/utils/insert.py
+++ b/src/matchbox/server/postgresql/utils/insert.py
@@ -162,6 +162,19 @@ def insert_hashes(
 
             adbc_connection.commit()
 
+            # Copy doesn't update pg_stats, must be done manually
+            table_names = [
+                Clusters.__table__.fullname,
+                ClusterSourceKey.__table__.fullname,
+            ]
+            with adbc_connection.cursor() as cursor:
+                cursor.execute(f"ANALYZE {', '.join(table_names)}")
+
+            logger.info(
+                f"Updated pg_stats for tables: {', '.join(table_names)}",
+                prefix=log_prefix,
+            )
+
         except Exception as e:
             # Log the error and rollback
             logger.warning(f"Error, rolling back: {e}", prefix=log_prefix)
@@ -599,6 +612,22 @@ def insert_results(
             )
 
             adbc_connection.commit()
+
+            # Copy doesn't update pg_stats, must be done manually
+            table_names = [
+                Clusters.__table__.fullname,
+                Contains.__table__.fullname,
+                Probabilities.__table__.fullname,
+                Results.__table__.fullname,
+            ]
+            with adbc_connection.cursor() as cursor:
+                cursor.execute(f"ANALYZE {', '.join(table_names)}")
+
+            logger.info(
+                f"Updated pg_stats for tables: {', '.join(table_names)}",
+                prefix=log_prefix,
+            )
+
         except Exception as e:
             logger.error(
                 f"Failed to insert data, rolling back: {str(e)}", prefix=log_prefix


### PR DESCRIPTION
We've noticed that ingesting via `COPY` doesn't trigger `ANALYZE`. Without the right stats, query planning can be thrown when an empty table suddenly becomes very very not-empty.

## 🛠️ Changes proposed in this pull request

Adds manual `ANALYZE` for all ingest operations.

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## 🔗 Relevant links

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
