### PR TITLE
Added `vacuum` to `analyze` and moved to its own transaction

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,16 @@ services:
       - POSTGRES_DB=matchbox
       - POSTGRES_PASSWORD=matchbox_password
       - POSTGRES_USER=matchbox_user
+    # command:
+    #   - "postgres"
+    #   - "-c"
+    #   - "log_statement=all"
+    #   - "-c"
+    #   - "log_connections=on"
+    #   - "-c"
+    #   - "log_disconnections=on"
+    #   - "-c"
+    #   - "log_duration=on"
   redis:
     image: redis:8
     restart: always


### PR DESCRIPTION
We're not seeing `analyze` update properly in production, even though it's in the logs. We think it's either:

* A race condition between instances
* Indices not being properly updated a la [this comment](https://github.com/uktrade/data-flow/blob/380bc000d02c413051c7e96c73a933f13d0feedd/dags/data_infrastructure/operators/db_tables.py#L299), though we believe if this was the solution it's more that `vacuum` has a more demanding lock than `analyze` does

## 🛠️ Changes proposed in this pull request

Adds a generic `vacuum analyze` function and uses it in our ingestion.

Does this as part of a separate connection outside of the `large_append()` function usage.

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## 🔗 Relevant links

* [`vacuum` documentation](https://www.postgresql.org/docs/current/sql-vacuum.html)

## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
