### PR TITLE
Change logging plugin to standard formatter

### DIFF
--- a/src/matchbox/common/logging.py
+++ b/src/matchbox/common/logging.py
@@ -2,7 +2,7 @@
 
 import importlib.metadata
 import logging
-from typing import Any, Final, Literal, Protocol
+from typing import Any, Final, Literal
 
 from rich.console import Console
 from rich.progress import (
@@ -14,24 +14,11 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 
-
-class LoggingPlugin(Protocol):
-    """Protocol for logging plugins that can be registered with Matchbox."""
-
-    def get_trace_context(self) -> tuple[str | None, str | None]:
-        """Get trace context information for logging."""
-        ...
-
-    def get_metadata(self) -> dict[str, Any]:
-        """Get additional fields for logging."""
-        ...
-
-
 _PLUGINS = None
 
 
-def get_logging_plugins():
-    """Retrieve logging plugins registered in the 'matchbox.logging' entry point."""
+def get_formatter() -> logging.Formatter:
+    """Retrieve plugin registered in 'matchbox.logging' entry point, or fallback."""
     global _PLUGINS
     if _PLUGINS is None:
         _PLUGINS = []
@@ -40,7 +27,11 @@ def get_logging_plugins():
                 _PLUGINS.append(ep.load()())
             except Exception as e:  # noqa: BLE001
                 logger.warning(f"Failed to load logging plugin: {e}")
-    return _PLUGINS
+
+    if len(_PLUGINS):
+        return _PLUGINS[0]
+
+    return logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 
 LogLevelType = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/src/matchbox/server/api/dependencies.py
+++ b/src/matchbox/server/api/dependencies.py
@@ -21,6 +21,7 @@ from fastapi import (
 from fastapi.responses import Response
 from fastapi.security import APIKeyHeader
 
+from matchbox.common.logging import get_formatter
 from matchbox.server.base import (
     MatchboxDBAdapter,
     MatchboxServerSettings,
@@ -96,6 +97,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         # Configure handler
         handler = logging.StreamHandler(sys.stdout)
         handler.setLevel(BACKEND.settings.log_level)
+        handler.setFormatter(get_formatter())
 
         logger = logging.getLogger(logger_name)
         logger.setLevel(BACKEND.settings.log_level)


### PR DESCRIPTION
Previous plugin system for logging was too tied to our own setup.

## 🛠️ Changes proposed in this pull request

* Changed plugin system to expect a standard `logging.Formatter`, and default to a sensible fallback.

## 👀 Guidance to review

Note that at the moment multiple plugins will result in only one of them being selected without any particular criterion. In the future we might regulate this with an environment variable.

## 🤖 AI declaration

None

## 🔗 Relevant links

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
