### PR TITLE
Catch lack of overlapping eval pairs before division by 0

### DIFF
--- a/src/matchbox/common/eval.py
+++ b/src/matchbox/common/eval.py
@@ -123,10 +123,15 @@ def precision_recall(
         and validation_net_count[(a, b)] > 0
     }
 
+    if not validation_pairs:
+        raise ValueError("Validation data has no pairs to evaluate.")
+
     # Compute PR scores for each model
     pr_scores: list[PrecisionRecall] = []
-    for model_pairs in pairs_per_model:
+    for i, model_pairs in enumerate(pairs_per_model):
         true_positive_pairs = model_pairs & validation_pairs
+        if not model_pairs:
+            raise ValueError(f"Model at index {i} has no pairs to evaluate.")
         pr_scores.append(
             (
                 len(true_positive_pairs) / len(model_pairs),

--- a/test/common/test_eval.py
+++ b/test/common/test_eval.py
@@ -41,6 +41,16 @@ def test_precision_recall_fails() -> None:
             models_root_leaf=[empty_model], judgements=judgements, expansion=expansion
         )
 
+    # No common leaves
+    mismatched_model = pl.DataFrame([{"root": 34, "leaf": 3}, {"root": 34, "leaf": 4}])
+
+    with pytest.raises(ValueError, match="no pairs to evaluate"):
+        precision_recall(
+            models_root_leaf=[model, mismatched_model],
+            judgements=judgements,
+            expansion=expansion,
+        )
+
 
 def test_precision_recall() -> None:
     """Test calculation of precision and recall from root-leaf tables."""


### PR DESCRIPTION

## 🛠️ Changes proposed in this pull request

Check that the result of filtering out pairs without overlapping leaves isn't empty sets, to avoid division by 0 error.

## 👀 Guidance to review

None

## 🤖 AI declaration

NA

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
