### PR TITLE
Turns authorisation on by default

### DIFF
--- a/src/matchbox/server/base.py
+++ b/src/matchbox/server/base.py
@@ -120,7 +120,7 @@ class MatchboxServerSettings(BaseSettings):
     task_runner: Literal["api", "celery"]
     redis_uri: str | None
     uploads_expiry_minutes: int | None
-    authorisation: bool = False
+    authorisation: bool = True
     public_key: SecretStr | None = Field(default=None)
     log_level: LogLevelType = "INFO"
 


### PR DESCRIPTION
We had it off by default. Wrong. I've kept the setting in there for local debugging but it defaults to on.

## 🛠️ Changes proposed in this pull request

Turns authorisation on by default.

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
