### PR TITLE
fix: support sampling with convergent sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
 # Mandatory internal hooks
 - repo: https://github.com/uktrade/github-standards
-  rev: v0.0.18  # update periodically with pre-commit autoupdate
+  rev: v0.0.19  # update periodically with pre-commit autoupdate
   hooks:
     - id: run-security-scan
       verbose: false


### PR DESCRIPTION
There was an issue (untracked) that meant that when a source cluster mapped to multiple keys across different source resolutions, those were being pulled in a sample even when those sources where not relevant from the resolution being sampled from.

## 🛠️ Changes proposed in this pull request

* Solve bug by changing sampling query

## 👀 Guidance to review

I've renamed existing `convergent` scenario to `convergent_partial`.

## 🤖 AI declaration

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
