### PR TITLE
feat: allow client DAG to list available collections

### DIFF
--- a/src/matchbox/client/_handler.py
+++ b/src/matchbox/client/_handler.py
@@ -285,6 +285,15 @@ def match(
 
 
 @http_retry
+def list_collections() -> list[CollectionName]:
+    """Get all existing collection names."""
+    logger.debug("Retrieving all collections")
+
+    res = CLIENT.get("/collections")
+    return [CollectionName(name) for name in res.json()]
+
+
+@http_retry
 def get_collection(name: CollectionName) -> Collection:
     """Get all runs and resolutions in a collection."""
     log_prefix = f"Collection {name}"

--- a/src/matchbox/client/dags.py
+++ b/src/matchbox/client/dags.py
@@ -96,6 +96,11 @@ class DAG:
 
         self.nodes[step.name] = step
 
+    @classmethod
+    def list_all(cls) -> list[CollectionName]:
+        """List available DAG names on the server."""
+        return _handler.list_collections()
+
     @property
     def run(self) -> RunID:
         """Return run ID if available, else error."""

--- a/test/client/test_dags.py
+++ b/test/client/test_dags.py
@@ -41,6 +41,13 @@ from matchbox.common.factories.sources import (
 )
 
 
+def test_dag_list(matchbox_api: MockRouter) -> None:
+    """Can retrieve list of DAG names."""
+    dummy_names = ["companies", "contacts"]
+    matchbox_api.get("/collections").mock(return_value=Response(200, json=dummy_names))
+    assert DAG.list_all() == ["companies", "contacts"]
+
+
 @patch.object(Source, "run")
 @patch.object(Model, "run")
 @patch.object(Source, "sync")


### PR DESCRIPTION
Closes https://github.com/uktrade/matchbox/issues/311

## 🛠️ Changes proposed in this pull request
Allow client DAG to list available collections on server

## 👀 Guidance to review

Aligns with existing method name advertised in the tutorial `explore-dags.md` 

## 🤖 AI declaration

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
