### PR TITLE
feat: ensure no duplicate pairs in model results

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
 # Mandatory internal hooks
 - repo: https://github.com/uktrade/github-standards
-  rev: v0.0.19  # update periodically with pre-commit autoupdate
+  rev: v1.0.1  # update periodically with pre-commit autoupdate
   hooks:
     - id: run-security-scan
       verbose: false

--- a/test/client/test_dags.py
+++ b/test/client/test_dags.py
@@ -995,7 +995,7 @@ def test_dag_load_server_run(matchbox_api: MockRouter) -> None:
 def test_dag_load_run_complex_dependencies(matchbox_api: MockRouter) -> None:
     """Test that _load_run handles nodes with complex dependencies.
 
-    In particular, tests for DAGS where nodes have the same dependency count but
+    In particular, tests for DAGs where nodes have the same dependency count but
     inter-dependencies between them.
     """
     test_dag = TestkitDAG().dag
@@ -1003,6 +1003,7 @@ def test_dag_load_run_complex_dependencies(matchbox_api: MockRouter) -> None:
     linked_testkit = linked_sources_factory(dag=test_dag)
     crn_testkit = linked_testkit.sources["crn"].fake_run()
     dh_testkit = linked_testkit.sources["dh"].fake_run()
+    cdms_testkit = linked_testkit.sources["cdms"].fake_run()
 
     # model_inner depends on 2 sources (count=2)
     model_inner_testkit = model_factory(
@@ -1018,7 +1019,7 @@ def test_dag_load_run_complex_dependencies(matchbox_api: MockRouter) -> None:
     model_outer_testkit = model_factory(
         name="model_outer",
         left_testkit=model_inner_testkit,  # depends on model_inner!
-        right_testkit=crn_testkit,
+        right_testkit=cdms_testkit,
         true_entities=linked_testkit.true_entities,
         dag=test_dag,
     ).fake_run()
@@ -1026,6 +1027,7 @@ def test_dag_load_run_complex_dependencies(matchbox_api: MockRouter) -> None:
     # Add to original DAG
     test_dag.source(**crn_testkit.into_dag())
     test_dag.source(**dh_testkit.into_dag())
+    test_dag.source(**cdms_testkit.into_dag())
     test_dag.model(**model_inner_testkit.into_dag())
     test_dag.model(**model_outer_testkit.into_dag())
 
@@ -1034,6 +1036,7 @@ def test_dag_load_run_complex_dependencies(matchbox_api: MockRouter) -> None:
         model_outer_testkit.name: model_outer_testkit.model.to_resolution(),  # 2 deps
         crn_testkit.name: crn_testkit.source.to_resolution(),  # 0 deps
         dh_testkit.name: dh_testkit.source.to_resolution(),  # 0 deps
+        cdms_testkit.name: cdms_testkit.source.to_resolution(),  # 0 deps
         model_inner_testkit.name: model_inner_testkit.model.to_resolution(),  # 2 deps
     }
 

--- a/test/client/test_results.py
+++ b/test/client/test_results.py
@@ -12,6 +12,53 @@ from matchbox.common.factories.sources import source_from_tuple
 class TestModelResults:
     """Test ModelResult objects."""
 
+    def test_duplicate_removal(self) -> None:
+        """Removes redundant pairs, keeping lowest probability."""
+        simple_duplicate = pl.DataFrame(
+            [
+                {"left_id": 4, "right_id": 5, "probability": 100},
+                {"left_id": 4, "right_id": 5, "probability": 50},
+            ]
+        )
+
+        assert_frame_equal(
+            ModelResults(probabilities=simple_duplicate).probabilities,
+            simple_duplicate.tail(1),
+            check_row_order=False,
+            check_column_order=False,
+            check_dtypes=False,
+        )
+
+        symmetric_duplicate = pl.DataFrame(
+            [
+                {"left_id": 4, "right_id": 5, "probability": 100},
+                {"left_id": 5, "right_id": 4, "probability": 50},
+            ]
+        )
+
+        assert_frame_equal(
+            ModelResults(probabilities=symmetric_duplicate).probabilities,
+            symmetric_duplicate.tail(1),
+            check_row_order=False,
+            check_column_order=False,
+            check_dtypes=False,
+        )
+
+        no_duplicates = pl.DataFrame(
+            [
+                {"left_id": 4, "right_id": 5, "probability": 100},
+                {"left_id": 4, "right_id": 6, "probability": 50},
+            ]
+        )
+
+        assert_frame_equal(
+            ModelResults(probabilities=no_duplicates).probabilities,
+            no_duplicates,
+            check_row_order=False,
+            check_column_order=False,
+            check_dtypes=False,
+        )
+
     def test_clusters_and_root_leaf(self) -> None:
         """From a results object, we can derive clusters at various levels."""
         # Prepare dummy data and model


### PR DESCRIPTION
Closes https://github.com/uktrade/matchbox/issues/288

## 🛠️ Changes proposed in this pull request

* Added pair duplication identification in `ModelResults` to ensure (symmetrically) that no duplicate pairs can be returned

## 👀 Guidance to review

I toyed with raising an error in case of duplicates, instead of dropping the duplicates, but I was getting a Splink linker in tests giving me duplicates. Why?

Splink (and in fact all models we have defined) expect a unique ID to express the rows they want to merge. The ID we provide is the cluster ID. If for whatever reason, the ID is repeated on the left and right (for example, if the source rows on the left and right have identical field values), then you could generate duplicate pairs by accident. For example, Splink could see

- IDs 1 and 2 on the left
- IDs 1 and 2 on the right

If Splink is asked to deduplicate as well as link, it could link 1 to 2 on both left and right, thus generating duplicate pairs in the output. Alternatively it could link 1 (on the left) to 2 (on the right), and 2 (on the left) to 1 (on the right) and output both because semantically for Splink if they're in different dataframes they're different rows, whereas semantically for Matchbox if they have the same matchbox ID they are the exact same row. 

So we must do the error correction outside of Splink. Doing it for all model results felt like the safest option. The only alternatives I can think of are:

- do the deduplication separately for each type of model (feels unnecessary and error-prone)
- ensure a model is never passed identical rows on the left and on the right, but this feels less conceptually right.

## 🤖 AI declaration

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
