### PR TITLE
Delete node data when running whole DAG

### DIFF
--- a/src/matchbox/client/dags.py
+++ b/src/matchbox/client/dags.py
@@ -445,8 +445,15 @@ class DAG:
         self,
         start: str | None = None,
         finish: str | None = None,
+        low_memory: bool = False,
     ) -> None:
-        """Run entire DAG and send results to server."""
+        """Run entire DAG and send results to server.
+
+        Args:
+            start: name of first node to run
+            finish: name of last node to run
+            low_memory: whether to delete data for each node after it is run
+        """
         # Determine order of execution steps
         root_nodes = self.final_steps
 
@@ -499,6 +506,9 @@ class DAG:
                 logger.error(f"❌ {node.name} failed: {e}")
                 raise e
             status[step_name] = DAGNodeExecutionStatus.DONE
+
+            if low_memory:
+                node.clear_data()
         logger.info("\n" + self.draw(status=status))
 
     def set_default(self) -> None:

--- a/src/matchbox/client/models/models.py
+++ b/src/matchbox/client/models/models.py
@@ -336,3 +336,10 @@ class Model:
     def query(self, *sources: Source, **kwargs: Any) -> Query:
         """Generate a query for this model."""
         return Query(*sources, **kwargs, model=self, dag=self.dag)
+
+    def clear_data(self) -> None:
+        """Deletes data computed for node."""
+        self.results = None
+        self.left_query._set_cache(None, None)
+        if self.right_query:
+            self.right_query._set_cache(None, None)

--- a/src/matchbox/client/sources.py
+++ b/src/matchbox/client/sources.py
@@ -420,3 +420,7 @@ class Source:
     def query(self, **kwargs: Any) -> Query:
         """Generate a query for this source."""
         return Query(self, **kwargs, dag=self.dag)
+
+    def clear_data(self) -> None:
+        """Deletes data computed for node."""
+        self.hashes = None

--- a/test/client/test_dags.py
+++ b/test/client/test_dags.py
@@ -52,7 +52,11 @@ def test_dag_list(matchbox_api: MockRouter) -> None:
 @patch.object(Model, "run")
 @patch.object(Source, "sync")
 @patch.object(Model, "sync")
+@patch.object(Source, "clear_data")
+@patch.object(Model, "clear_data")
 def test_dag_run_and_sync(
+    model_clear_mock: Mock,
+    source_clear_mock: Mock,
     model_sync_mock: Mock,
     source_sync_mock: Mock,
     model_run_mock: Mock,
@@ -113,6 +117,13 @@ def test_dag_run_and_sync(
     assert source_sync_mock.call_count == 3
     assert model_run_mock.call_count == 3
     assert model_sync_mock.call_count == 3
+    source_clear_mock.assert_not_called()
+    model_clear_mock.assert_not_called()
+
+    # Running DAG destroys intermediate results
+    dag.run_and_sync(low_memory=True)
+    assert source_clear_mock.call_count == 3
+    assert model_clear_mock.call_count == 3
 
 
 def test_dags_missing_dependency(sqlite_warehouse: Engine) -> None:


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

* Delete data in sources, models and queries when running whole DAG, after node is synced, to save memory.

## 👀 Guidance to review

Considered https://github.com/uktrade/matchbox/issues/389 and https://github.com/uktrade/matchbox/issues/390 out of scope

## 🤖 AI declaration

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
