### PR TITLE
feat: improve dag profiling

### DIFF
--- a/src/matchbox/client/_handler.py
+++ b/src/matchbox/client/_handler.py
@@ -65,7 +65,7 @@ from matchbox.common.exceptions import (
     MatchboxUserNotFoundError,
 )
 from matchbox.common.hash import hash_to_base64
-from matchbox.common.logging import logger, profile_time
+from matchbox.common.logging import logger
 
 URLEncodeHandledType = str | int | float | bytes | StrEnum
 
@@ -422,7 +422,6 @@ def update_resolution(
     return ResourceOperationStatus.model_validate(res.json())
 
 
-@profile_time(kwarg="path")
 @http_retry
 def get_resolution(path: ResolutionPath) -> Resolution | None:
     """Get a resolution from Matchbox."""
@@ -435,7 +434,6 @@ def get_resolution(path: ResolutionPath) -> Resolution | None:
     return Resolution.model_validate(res.json())
 
 
-@profile_time(kwarg="path")
 @http_retry
 def set_data(path: ResolutionPath, data: pl.DataFrame | Table) -> None:
     """Upload source hashes or model results to server."""
@@ -482,7 +480,6 @@ def get_resolution_stage(path: ResolutionPath) -> UploadStage:
     return upload_info.stage
 
 
-@profile_time(kwarg="path")
 @http_retry
 def get_results(path: ModelResolutionPath) -> Table:
     """Get model results from Matchbox."""

--- a/src/matchbox/client/models/models.py
+++ b/src/matchbox/client/models/models.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
 
+from polars import DataFrame
+
 from matchbox.client import _handler
 from matchbox.client._settings import settings
 from matchbox.client.models import dedupers, linkers
@@ -24,7 +26,7 @@ from matchbox.common.dtos import (
 )
 from matchbox.common.exceptions import MatchboxResolutionNotFoundError
 from matchbox.common.hash import hash_model_results
-from matchbox.common.logging import logger, profile_mem, profile_time
+from matchbox.common.logging import logger, profile_time
 from matchbox.common.transform import threshold_float_to_int, threshold_int_to_float
 
 if TYPE_CHECKING:
@@ -234,8 +236,20 @@ class Model:
         result = _handler.delete_resolution(path=self.resolution_path, certain=certain)
         return result.success
 
-    @profile_mem()
     @profile_time(attr="name")
+    def compute_probabilities(
+        self, left_df: DataFrame, right_df: DataFrame | None = None
+    ) -> DataFrame:
+        """Run model instance against data."""
+        if self.config.type == ModelType.LINKER:
+            self.model_instance.prepare(left_df, right_df)
+            probabilities = self.model_instance.link(left=left_df, right=right_df)
+        else:
+            self.model_instance.prepare(left_df)
+            probabilities = self.model_instance.dedupe(data=left_df)
+
+        return probabilities
+
     def run(
         self, for_validation: bool = False, cache_queries: bool = False
     ) -> ModelResults:
@@ -265,27 +279,23 @@ class Model:
                 reuse_cache=cache_queries,
             )
 
-            self.model_instance.prepare(left_df, right_df)
-            results = self.model_instance.link(left=left_df, right=right_df)
-        else:
-            self.model_instance.prepare(left_df)
-            results = self.model_instance.dedupe(data=left_df)
+        logger.info("Running model logic", prefix=log_prefix)
+        probabilities = self.compute_probabilities(left_df, right_df)
 
         if for_validation:
             self.results = ModelResults(
-                probabilities=results,
+                probabilities=probabilities,
                 left_root_leaf=self.left_query.leaf_id,
                 right_root_leaf=self.right_query.leaf_id
                 if right_df is not None
                 else None,
             )
         else:
-            self.results = ModelResults(probabilities=results)
+            self.results = ModelResults(probabilities=probabilities)
 
         return self.results
 
     @post_run
-    @profile_mem()
     @profile_time(attr="name")
     def sync(self) -> None:
         """Send the model config and results to the server.
@@ -296,8 +306,8 @@ class Model:
         resolution = self.to_resolution()
         try:
             existing_resolution = _handler.get_resolution(path=self.resolution_path)
-        except MatchboxResolutionNotFoundError:
             logger.info("Found existing resolution", prefix=log_prefix)
+        except MatchboxResolutionNotFoundError:
             existing_resolution = None
 
         if existing_resolution:

--- a/src/matchbox/client/queries.py
+++ b/src/matchbox/client/queries.py
@@ -17,6 +17,7 @@ from matchbox.common.dtos import (
     QueryCombineType,
     QueryConfig,
 )
+from matchbox.common.logging import profile_time
 from matchbox.common.transform import threshold_float_to_int, threshold_int_to_float
 
 if TYPE_CHECKING:
@@ -157,6 +158,7 @@ class Query:
         if self._cache_mode == CacheMode.CLEAN:
             self.data = data
 
+    @profile_time()
     def run(
         self,
         return_type: QueryReturnType = QueryReturnType.POLARS,

--- a/src/matchbox/client/sources.py
+++ b/src/matchbox/client/sources.py
@@ -24,7 +24,7 @@ from matchbox.common.dtos import (
 )
 from matchbox.common.exceptions import MatchboxResolutionNotFoundError
 from matchbox.common.hash import HashMethod, hash_arrow_table, hash_rows
-from matchbox.common.logging import logger, profile_mem, profile_time
+from matchbox.common.logging import logger, profile_time
 
 if TYPE_CHECKING:
     from matchbox.client.dags import DAG
@@ -223,7 +223,6 @@ class Source:
             return False
         return self.config == other.config
 
-    @profile_time(attr="name")
     def fetch(
         self,
         qualify_names: bool = False,
@@ -270,7 +269,6 @@ class Source:
                 return_type=return_type,
             )
 
-    @profile_mem()
     @profile_time(attr="name")
     def run(self, batch_size: int | None = None) -> ArrowTable:
         """Hash a dataset from its warehouse, ready to be inserted, and cache hashes.
@@ -376,7 +374,6 @@ class Source:
         return self.config.f(self.name, fields)
 
     @post_run
-    @profile_mem()
     @profile_time(attr="name")
     def sync(self) -> None:
         """Send the source config and hashes to the server.
@@ -387,8 +384,8 @@ class Source:
         resolution = self.to_resolution()
         try:
             existing_resolution = _handler.get_resolution(path=self.resolution_path)
-        except MatchboxResolutionNotFoundError:
             logger.info("Found existing resolution", prefix=log_prefix)
+        except MatchboxResolutionNotFoundError:
             existing_resolution = None
 
         if existing_resolution:


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

* Replaced memory profiling strategy: it was returning values that were wrong when run inside a container, it was ignoring allocations outside of Python, and it wasn't giving us a total per process
* Started making profiling logs optional
* Placed timing decorator in more strategic locations
* Fixed mistake in log for sources and models' sync operation

## 👀 Guidance to review
None

## 🤖 AI declaration
AI suggested the logic behind the new memory profiling function

## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [ ] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
