### PR TITLE
Optimise insert operations

### DIFF
--- a/src/matchbox/server/postgresql/utils/insert.py
+++ b/src/matchbox/server/postgresql/utils/insert.py
@@ -118,7 +118,6 @@ def insert_hashes(
 
     existing_hash_lookup = _fetch_existing_clusters(data_hashes, "hash")
 
-    # Convert to polars after getting existing hashes to save one conversion
     data_hashes: pl.DataFrame = pl.from_arrow(data_hashes)
 
     # Don't insert new hashes, but new keys need existing hash IDs


### PR DESCRIPTION
We had instances of suspected OOM in Celery workers, so had a look at optimising the insert data module.

The main memory drain was loading the whole Clusters table every time. Other things I tried but turned out to either increase processing time or not reduce memory use substantially:
- Exploding list in batches
- Avoid concat and use joins instead
- Avoid unnecessary conversions between arrow and polars

## 🛠️ Changes proposed in this pull request

Two main changes:
- Clusters table not loaded every time. Only those hashes that match the new hashes being inserted are loaded. 
- Added manual removal of objects once they are no longer required

Using benchmarking in the mock pipeline, I saw reductions of running time by about half, and reduced memory use by a factor of 4.

## 👀 Guidance to review

Getting only a subset of clusters was a bit tricky because hashes are binary and they can't be used with `compile_sql`. I created a new helper function to use parameter binding and insert the hashes into a query in their raw format.

## 🤖 AI declaration

Some help debugging SQLAlchemy.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
