### PR TITLE
Keep largest prob in duplicate pairs

### DIFF
--- a/src/matchbox/client/results.py
+++ b/src/matchbox/client/results.py
@@ -83,14 +83,16 @@ class ModelResults:
                 .list.join("_")
                 .alias("sorted_ids")
             )
-            .sort("probability")  # sort so smallest probability comes first
+            .sort(
+                "probability", descending=True
+            )  # sort so largest probability comes first
             .unique(
                 subset=["sorted_ids"], keep="first"
             )  # keep first occurrence after sorting
         ).drop("sorted_ids")
         if len(probabilities) != len(unique_probabilities):
             logger.warning(
-                "Duplicate pairs! Keeping only pairs with lowest probability."
+                "Duplicate pairs! Keeping only pairs with highest probability."
             )
 
         # Process probability field if it contains floating-point or decimal values

--- a/test/client/test_results.py
+++ b/test/client/test_results.py
@@ -17,8 +17,8 @@ class TestModelResults:
         """Removes redundant pairs, keeping lowest probability."""
         simple_duplicate = pl.DataFrame(
             [
-                {"left_id": 4, "right_id": 5, "probability": 100},
                 {"left_id": 4, "right_id": 5, "probability": 50},
+                {"left_id": 4, "right_id": 5, "probability": 100},
             ]
         )
 
@@ -32,8 +32,8 @@ class TestModelResults:
 
         symmetric_duplicate = pl.DataFrame(
             [
-                {"left_id": 4, "right_id": 5, "probability": 100},
                 {"left_id": 5, "right_id": 4, "probability": 50},
+                {"left_id": 4, "right_id": 5, "probability": 100},
             ]
         )
 
@@ -47,8 +47,8 @@ class TestModelResults:
 
         no_duplicates = pl.DataFrame(
             [
-                {"left_id": 4, "right_id": 5, "probability": 100},
                 {"left_id": 4, "right_id": 6, "probability": 50},
+                {"left_id": 4, "right_id": 5, "probability": 100},
             ]
         )
 


### PR DESCRIPTION
Related to this closed issue: https://github.com/uktrade/matchbox/issues/405


## 🛠️ Changes proposed in this pull request

A previous PR added logic to remove duplicate pairs in model results, but kept the smallest. Turns out, there are situations where we accept duplicate pairs as a feature, and in those cases we actually want to keep the largest probability. That's what this PR does.


## 👀 Guidance to review

None

## 🤖 AI declaration

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
