### PR TITLE
Simplify logging setup in tutorial

### DIFF
--- a/docs/client/link-data.md
+++ b/docs/client/link-data.md
@@ -50,16 +50,10 @@ Before building a pipeline, it's worth configuring logging:
 
     # Configure logging
     logging.basicConfig(
-        level=logging.DEBUG,
         format="%(asctime)s [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    logger = logging.getLogger()
-
-    # Reduce noise from HTTP libraries
-    logging.getLogger("httpcore").setLevel(logging.WARNING)
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-    logging.getLogger("http").setLevel(logging.WARNING)
+    logging.getLogger("matchbox").setLevel(logging.INFO)
     ```
 
 You will also need to define the engine to read your data sources:


### PR DESCRIPTION
Closes https://github.com/uktrade/matchbox/issues/312

## 🛠️ Changes proposed in this pull request
Change logging snippet in linking tutorial to be more library-agnostic.

## 👀 Guidance to review
This has been tested successfully in our internal company pipelines repo. It moves the default from info to debug level, but it's simple enough to users to make a different choice based on what they need.

## 🤖 AI declaration

NA

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [x] Tutorials
    - [ ] Developer docs
