### PR TITLE
Added dummy public/private keys to the development.env

### DIFF
--- a/environments/development.env
+++ b/environments/development.env
@@ -12,6 +12,9 @@ MB__DEV__WAREHOUSE_PORT=7654
 MB__DEV__POSTGRES_BACKEND_PORT=5432
 MB__DEV__REDIS_PORT=6379
 MB__DEV__FLOWER_PORT=5555
+# Set with MB__SERVER__PUBLIC_KEY using uv run test/scripts/authorisation.py keygen
+# trufflehog:ignore
+MB__DEV__PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIPMJVIQACD9QNGi0219FHyDQUk8OUP1vkGwkdsis58hZ\n-----END PRIVATE KEY-----\n
 
 # Client configuration
 MB__CLIENT__API_ROOT=http://localhost:8000
@@ -30,6 +33,9 @@ MB__SERVER__AUTHORISATION=False
 MB__SERVER__TASK_RUNNER=celery
 MB__SERVER__REDIS_URI=redis://localhost:6379/0
 MB__SERVER__UPLOADS_EXPIRY_MINUTES=10_080
+# Set with MB__DEV__PRIVATE_KEY using uv run test/scripts/authorisation.py keygen
+# trufflehog:ignore
+MB__SERVER__PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAg6Jqls79JB04WSlqMkP5ta9gD62t5DyKNj0v6fWCemg=\n-----END PUBLIC KEY-----\n
 
 MB__SERVER__DATASTORE__HOST=localhost
 MB__SERVER__DATASTORE__PORT=9000


### PR DESCRIPTION
I forgot to add these dummy keys to the example environment. They're useful so people don't need to generate them, and can be used to generate JWTs in other local services you're testing.

## 🛠️ Changes proposed in this pull request

Adds dummy private/public keys to development env vars.

## 👀 Guidance to review

None.

## 🤖 AI declaration

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
