### PR TITLE
Allow judgement to report new shown clusters

### DIFF
--- a/src/matchbox/client/cli/eval/app.py
+++ b/src/matchbox/client/cli/eval/app.py
@@ -72,11 +72,11 @@ class EvaluationQueue:
         if not sessions:
             return 0
 
-        existing_ids = {session.item.cluster_id for session in self.sessions}
+        existing_ids = {tuple(sorted(session.item.leaves)) for session in self.sessions}
         unique_items = [
             session
             for session in sessions
-            if session.item.cluster_id not in existing_ids
+            if tuple(sorted(session.item.leaves)) not in existing_ids
         ]
 
         if unique_items:

--- a/src/matchbox/client/eval/samples.py
+++ b/src/matchbox/client/eval/samples.py
@@ -45,7 +45,7 @@ class EvaluationItem(BaseModel):
 
     model_config = {"arbitrary_types_allowed": True}
 
-    cluster_id: int
+    leaves: list[int]
     records: pl.DataFrame
     fields: list[EvaluationFieldMetadata]
 
@@ -95,13 +95,11 @@ def create_judgement(
         groups.setdefault(group, []).extend(leaf_ids)
 
     endorsed = [sorted(set(leaf_ids)) for leaf_ids in groups.values()]
-    return Judgement(
-        user_name=user_name, shown=item.cluster_id, endorsed=endorsed, tag=tag
-    )
+    return Judgement(user_name=user_name, shown=item.leaves, endorsed=endorsed, tag=tag)
 
 
 def create_evaluation_item(
-    df: pl.DataFrame, source_configs: list[tuple[str, SourceConfig]], cluster_id: int
+    df: pl.DataFrame, source_configs: list[tuple[str, SourceConfig]], leaves: list[int]
 ) -> EvaluationItem:
     """Create EvaluationItem with structured metadata."""
     # Get all data columns (exclude metadata columns)
@@ -134,7 +132,7 @@ def create_evaluation_item(
     # Keep ALL data columns in records
     records = df.select(["leaf"] + data_cols)
 
-    return EvaluationItem(cluster_id=cluster_id, records=records, fields=fields)
+    return EvaluationItem(leaves=leaves, records=records, fields=fields)
 
 
 def _read_sample_file(sample_file: str, n: int) -> pl.DataFrame:
@@ -233,7 +231,8 @@ def get_samples(
     results_by_root: dict[int, EvaluationItem] = {}
     for root in all_results["root"].unique():
         cluster_df = all_results.filter(pl.col("root") == root).drop("root")
-        evaluation_item = create_evaluation_item(cluster_df, source_configs, root)
+        leaves = cluster_df.select("leaf").to_series().to_list()
+        evaluation_item = create_evaluation_item(cluster_df, source_configs, leaves)
         results_by_root[root] = evaluation_item
 
     return results_by_root

--- a/src/matchbox/common/eval.py
+++ b/src/matchbox/common/eval.py
@@ -1,10 +1,10 @@
 """Common operations to produce model evaluation scores."""
 
 from itertools import chain, combinations
-from typing import TypeAlias
+from typing import Self, TypeAlias
 
 import polars as pl
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 Pair: TypeAlias = tuple[int, int]
 Pairs: TypeAlias = set[Pair]
@@ -17,22 +17,36 @@ class Judgement(BaseModel):
 
     user_name: str
     tag: str | None = None
-    shown: int = Field(description="ID of the model cluster shown to the user")
+    shown: list[int] = Field(
+        description="IDs of the source clusters shown to user at once"
+    )
     endorsed: list[list[int]] = Field(
         description="""Groups of source cluster IDs that user thinks belong together"""
     )
 
     @field_validator("endorsed", mode="before")
     @classmethod
-    def check_endorsed(cls, value: list[list[int]]) -> list[list[int]]:
+    def check_no_duplicates(cls, value: list[list[int]]) -> list[list[int]]:
         """Ensure no cluster IDs are repeated in the endorsement."""
         concat_ids = list(chain(*value))
         if len(concat_ids) != len(set(concat_ids)):
             raise ValueError(
-                "One or more cluster IDs were repeated in the endorsement data."
+                "One or more cluster IDs were repeated in the endorsement data"
             )
 
         return value
+
+    @model_validator(mode="after")
+    def check_consistency(self) -> Self:
+        """Ensure union of endorsed clusters matches shown cluster."""
+        all_shown = set(self.shown)
+        all_endorsed = set(chain(*self.endorsed))
+        if all_shown != all_endorsed:
+            raise ValueError(
+                "Inconsistent source cluster IDs between shown and endorsed clusters"
+            )
+
+        return self
 
 
 def precision_recall(

--- a/src/matchbox/server/postgresql/adapter/eval.py
+++ b/src/matchbox/server/postgresql/adapter/eval.py
@@ -9,6 +9,7 @@ import polars as pl
 import pyarrow as pa
 from pyarrow import Table
 from sqlalchemy import BIGINT, func, select
+from sqlalchemy.orm import Session
 
 from matchbox.common.arrow import (
     SCHEMA_CLUSTER_EXPANSION,
@@ -50,12 +51,39 @@ class MatchboxPostgresEvaluationMixin:
     """Evaluation mixin for the PostgreSQL adapter for Matchbox."""
 
     def insert_judgement(self, judgement: CommonJudgement) -> None:  # noqa: D102
-        # Check that all referenced cluster IDs exist
-        ids = list(chain(*judgement.endorsed)) + [judgement.shown]
-        self.validate_ids(ids)
+        def get_or_create_cluster(leaves: list[int], session: Session) -> int:
+            # Compute hash corresponding to set of source clusters (leaves)
+            leaf_hashes = [
+                session.scalar(
+                    select(Clusters.cluster_hash).where(Clusters.cluster_id == leaf_id)
+                )
+                for leaf_id in leaves
+            ]
+            cluster_hash = hash_cluster_leaves(leaf_hashes)
 
-        # Note: we don't currently check that the shown cluster ID points to
-        # the source cluster IDs. We must assume this is well-formed.
+            # Add new cluster to session, if it doesn't exist already
+            if not (
+                cluster_id := session.scalar(
+                    select(Clusters.cluster_id).where(
+                        Clusters.cluster_hash == cluster_hash
+                    )
+                )
+            ):
+                cluster_id = PKSpace.reserve_block(table="clusters", block_size=1)
+                session.add(
+                    Clusters(
+                        cluster_id=cluster_id,
+                        cluster_hash=cluster_hash,
+                    )
+                )
+                for leaf_id in leaves:
+                    session.add(Contains(root=cluster_id, leaf=leaf_id))
+
+            return cluster_id
+
+        # Check that all referenced leaf IDs exist
+        ids = list(chain(*judgement.endorsed)) + judgement.shown
+        self.validate_ids(ids)
 
         # Check that the user exists
         with MBDB.get_session() as session:
@@ -67,47 +95,21 @@ class MatchboxPostgresEvaluationMixin:
                     f"User '{judgement.user_name}' not found"
                 )
 
-        for leaves in judgement.endorsed:
-            with MBDB.get_session() as session:
-                # Compute hash corresponding to set of source clusters (leaves)
-                leaf_hashes = [
-                    session.scalar(
-                        select(Clusters.cluster_hash).where(
-                            Clusters.cluster_id == leaf_id
-                        )
-                    )
-                    for leaf_id in leaves
-                ]
-                endorsed_cluster_hash = hash_cluster_leaves(leaf_hashes)
+        with MBDB.get_session() as session:
+            shown_id = get_or_create_cluster(judgement.shown, session)
+            session.commit()
 
+            for leaves in judgement.endorsed:
                 # If cluster with this hash does not exist, create it.
                 # Note that only endorsed clusters might be new. The cluster shown to
                 # the user is guaranteed to exist in the backend; we have checked above.
-                if not (
-                    endorsed_cluster_id := session.scalar(
-                        select(Clusters.cluster_id).where(
-                            Clusters.cluster_hash == endorsed_cluster_hash
-                        )
-                    )
-                ):
-                    endorsed_cluster_id = PKSpace.reserve_block(
-                        table="clusters", block_size=1
-                    )
-                    session.add(
-                        Clusters(
-                            cluster_id=endorsed_cluster_id,
-                            cluster_hash=endorsed_cluster_hash,
-                        )
-                    )
-                    for leaf_id in leaves:
-                        session.add(Contains(root=endorsed_cluster_id, leaf=leaf_id))
 
                 session.add(
                     EvalJudgements(
                         user_id=user.user_id,
                         tag=judgement.tag,
-                        shown_cluster_id=judgement.shown,
-                        endorsed_cluster_id=endorsed_cluster_id,
+                        shown_cluster_id=shown_id,
+                        endorsed_cluster_id=get_or_create_cluster(leaves, session),
                         timestamp=datetime.now(UTC),
                     )
                 )

--- a/test/client/cli/eval/test_app.py
+++ b/test/client/cli/eval/test_app.py
@@ -42,7 +42,7 @@ class TestEvaluationQueue:
     def test_add_items_increases_count(self) -> None:
         """Test adding items increases count."""
         queue = EvaluationQueue()
-        items = [Mock(item=Mock(cluster_id=1)), Mock(item=Mock(cluster_id=2))]
+        items = [Mock(item=Mock(leaves=[1, 2])), Mock(item=Mock(leaves=[3, 4]))]
 
         added = queue.add_sessions(items)
 
@@ -53,8 +53,8 @@ class TestEvaluationQueue:
     def test_add_items_prevents_duplicates(self) -> None:
         """Test that duplicate cluster IDs are not added."""
         queue = EvaluationQueue()
-        item1 = Mock(item=Mock(cluster_id=1))
-        item2 = Mock(item=Mock(cluster_id=1))  # Duplicate
+        item1 = Mock(item=Mock(leaves=[1, 2]))
+        item2 = Mock(item=Mock(leaves=[2, 1]))  # Duplicate
 
         queue.add_sessions([item1])
         added = queue.add_sessions([item2])
@@ -175,7 +175,7 @@ class TestScenarioIntegration:
                 assert pilot.app.query("Footer")
                 assert app.queue.total_count > 0
                 assert app.queue.current is not None
-                assert app.queue.current.item.cluster_id is not None
+                assert app.queue.current.item.leaves is not None
 
                 # 2. Test keyboard workflow: letter then digit
                 await pilot.press("a")

--- a/test/common/test_eval.py
+++ b/test/common/test_eval.py
@@ -7,14 +7,23 @@ from matchbox.common.eval import Judgement, precision_recall, process_judgements
 
 def test_judgement_validation() -> None:
     """Judgement validates source cluster IDs."""
-    with pytest.raises(ValueError):
-        Judgement(user_name="alice", shown=10, endorsed=[[1, 2, 3], [3, 4, 5]])
-
-    with pytest.raises(ValueError):
-        Judgement(user_name="alice", shown=10, endorsed=[[1, 2, 3, 1]])
+    # Repeated across groups
+    with pytest.raises(ValueError, match="repeated"):
+        Judgement(
+            user_name="alice", shown=[1, 2, 3, 4, 5], endorsed=[[1, 2, 3], [3, 4, 5]]
+        )
+    # Repeated within group
+    with pytest.raises(ValueError, match="repeated"):
+        Judgement(user_name="alice", shown=[1, 2, 3], endorsed=[[1, 2, 3, 1]])
+    # Missing leaf in endorsed
+    with pytest.raises(ValueError, match="Inconsistent"):
+        Judgement(user_name="alice", shown=[1, 2, 3], endorsed=[[1, 2]])
+    # Extra leaf in endorsed
+    with pytest.raises(ValueError, match="Inconsistent"):
+        Judgement(user_name="alice", shown=[1, 2, 3], endorsed=[[1, 2], [3, 4]])
 
     # Something sensible does work
-    Judgement(user_name="alice", shown=10, endorsed=[[1, 2, 3], [4, 5]])
+    Judgement(user_name="alice", shown=[1, 2, 3, 4, 5], endorsed=[[1, 2, 3], [4, 5]])
 
 
 def test_precision_recall_fails() -> None:

--- a/test/server/adapter/test_adapter_eval.py
+++ b/test/server/adapter/test_adapter_eval.py
@@ -71,7 +71,7 @@ class TestMatchboxEvaluationBackend:
             self.backend.insert_judgement(
                 judgement=Judgement(
                     user_name=alice.user_name,
-                    shown=unique_ids[0],
+                    shown=clust1_leaves,
                     endorsed=[clust1_leaves],
                 ),
             )
@@ -79,7 +79,7 @@ class TestMatchboxEvaluationBackend:
             self.backend.insert_judgement(
                 judgement=Judgement(
                     user_name=alice.user_name,
-                    shown=unique_ids[0],
+                    shown=clust1_leaves,
                     endorsed=[clust1_leaves],
                 ),
             )
@@ -89,7 +89,7 @@ class TestMatchboxEvaluationBackend:
             self.backend.insert_judgement(
                 judgement=Judgement(
                     user_name=alice.user_name,
-                    shown=unique_ids[0],
+                    shown=clust1_leaves,
                     endorsed=[clust1_leaves],
                     tag="eval_session1",
                 ),
@@ -100,12 +100,23 @@ class TestMatchboxEvaluationBackend:
             self.backend.insert_judgement(
                 judgement=Judgement(
                     user_name=alice.user_name,
-                    shown=unique_ids[1],
+                    shown=clust2_leaves,
                     endorsed=[clust2_leaves[:1], clust2_leaves[1:]],
                 ),
             )
             # Now, two new clusters should have been created
             assert self.backend.model_clusters.count() == original_cluster_num + 2
+
+            # Insert a judgement with a "shown" that doesn't exist on the server
+            self.backend.insert_judgement(
+                judgement=Judgement(
+                    user_name=alice.user_name,
+                    shown=clust1_leaves + clust2_leaves,
+                    endorsed=[clust1_leaves + clust2_leaves],
+                ),
+            )
+            # A single extra cluster is created
+            assert self.backend.model_clusters.count() == original_cluster_num + 3
 
             # Let's check failures
             # First, confirm that the following leaves don't exist
@@ -117,7 +128,7 @@ class TestMatchboxEvaluationBackend:
                 self.backend.insert_judgement(
                     judgement=Judgement(
                         user_name=alice.user_name,
-                        shown=unique_ids[0],
+                        shown=fake_leaves,
                         endorsed=[fake_leaves],
                     ),
                 )
@@ -129,41 +140,42 @@ class TestMatchboxEvaluationBackend:
             assert expansion.schema.equals(SCHEMA_CLUSTER_EXPANSION)
             # Only one user ID was used
             assert judgements["user_name"].unique().to_pylist() == [alice.user_name]
-            # The first shown cluster is repeated because we judged it three times
-            # The second shown cluster is repeated because we split it (see above)
-            assert sorted(judgements["shown"].to_pylist()) == sorted(
-                [
-                    unique_ids[0],
-                    unique_ids[0],
-                    unique_ids[0],
-                    unique_ids[1],
-                    unique_ids[1],
-                ]
-            )
+            # The set of shown judgements has the two IDs we know, plus a new one
+            assert set(judgements["shown"].to_pylist()) > {unique_ids[0], unique_ids[1]}
+
             # On the other hand, the root-leaf mapping table has no duplicates
-            assert len(expansion) == 4  # 2 shown clusters + 2 new endorsed clusters
+            # 2 shown clusters + 2 new endorsed clusters + 1 new shown cluster
+            assert len(expansion) == 5
 
             # We can use tag to filter judgements
             judgements_tag, expansion_tag = self.backend.get_judgements("eval_session1")
             assert judgements_tag.num_rows == 1
             assert expansion_tag.num_rows == 1
 
-            # Let's massage tables into a root-leaf dict for all endorsed clusters
-            endorsed_dict = dict(
-                pl.from_arrow(judgements)
-                .join(pl.from_arrow(expansion), left_on="endorsed", right_on="root")
-                .select(["endorsed", "leaves"])
-                .rows()
-            )
+            # We now ensure the expansion has all we need
+            # We get expansion for two known shown cluster IDs
+            expansion_df = pl.from_arrow(expansion)
+            assert sorted(
+                expansion_df.filter(pl.col("root") == unique_ids[0])
+                .select("leaves")
+                .to_series()
+                .to_list()[0]
+            ) == sorted(clust1_leaves)
 
-            # The root we know about has the leaves we expect
-            assert set(endorsed_dict[unique_ids[0]]) == set(clust1_leaves)
-            # Other than the root we know about, there are two new ones
-            assert len(set(endorsed_dict.keys())) == 3
-            # The other two sets of leaves are there too
-            assert set(map(frozenset, endorsed_dict.values())) == set(
-                map(frozenset, [clust1_leaves, clust2_leaves[:1], clust2_leaves[1:]])
-            )
+            assert sorted(
+                expansion_df.filter(pl.col("root") == unique_ids[1])
+                .select("leaves")
+                .to_series()
+                .to_list()[0]
+            ) == sorted(clust2_leaves)
+
+            # We get expansions of new clusters whose IDs are unknown
+            expansion_leaf_sets = [
+                sorted(ls[0]) for ls in pl.from_arrow(expansion).select("leaves").rows()
+            ]
+            assert sorted(clust2_leaves[:1]) in expansion_leaf_sets
+            assert sorted(clust2_leaves[1:]) in expansion_leaf_sets
+            assert sorted(clust1_leaves + clust2_leaves) in expansion_leaf_sets
 
     def test_sample_for_eval(self) -> None:
         """Can extract samples for a user and a resolution."""
@@ -253,7 +265,7 @@ class TestMatchboxEvaluationBackend:
             self.backend.insert_judgement(
                 judgement=Judgement(
                     user_name=alice.user_name,
-                    shown=first_cluster_id,
+                    shown=first_cluster_leaves,
                     endorsed=[first_cluster_leaves],
                 ),
             )
@@ -283,7 +295,7 @@ class TestMatchboxEvaluationBackend:
                 self.backend.insert_judgement(
                     judgement=Judgement(
                         user_name=alice.user_name,
-                        shown=cluster_id,
+                        shown=cluster_leaves,
                         endorsed=[cluster_leaves],
                     ),
                 )

--- a/test/server/api/routes/test_routes_eval.py
+++ b/test/server/api/routes/test_routes_eval.py
@@ -31,7 +31,7 @@ def test_insert_judgement_ok(
 ) -> None:
     """Test that a judgement is passed on to backend."""
     test_client, mock_backend, _ = api_client_and_mocks
-    judgement = Judgement(user_name="alice", shown=10, endorsed=[[1]])
+    judgement = Judgement(user_name="alice", shown=[1, 2], endorsed=[[1], [2]])
     response = test_client.post("/eval/judgements", json=judgement.model_dump())
     assert response.status_code == 201
     assert (
@@ -44,7 +44,9 @@ def test_insert_judgement_error(
 ) -> None:
     """Test that judgement insertion bubbles up errors."""
     test_client, mock_backend, _ = api_client_and_mocks
-    fake_judgement = Judgement(user_name="alice", shown=10, endorsed=[[1]]).model_dump()
+    fake_judgement = Judgement(
+        user_name="alice", shown=[1, 2], endorsed=[[1], [2]]
+    ).model_dump()
 
     mock_backend.insert_judgement = Mock(side_effect=MatchboxDataNotFound)
     response = test_client.post("/eval/judgements", json=fake_judgement)


### PR DESCRIPTION
Because we now  allow sampling from two `ResolvedMatches` objects jointly, sometimes our users are shown clusters which the backend has never seen before. Currently, the backend errors and rejects such judgements.

## 🛠️ Changes proposed in this pull request

* Change `Judgement` DTO to represent shown cluster as leaf set, instead of as ID, and change the client-side eval logic accordingly
* Change `insert_judgement()` to only ensure leaf IDs exist, and create new cluster for shown cluster leaf set if necessary

## 👀 Guidance to review

**BREAKING CHANGE** As this changes the DTO for judgements, the client and the server will need to be upgraded jointly, else, the eval CLI will break.

## 🤖 AI declaration

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
