### PR TITLE
Allow devs to drop MB schema altogether

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set dotenv-load := true
+
 # Unit testing
 mod test 'test/justfile'
 # PostgreSQL migration

--- a/src/matchbox/server/postgresql/justfile
+++ b/src/matchbox/server/postgresql/justfile
@@ -18,3 +18,11 @@ generate descriptive-message:
 # Reset the DB to the base state
 reset:
     uv run alembic --config "src/matchbox/server/postgresql/alembic.ini" downgrade base
+
+# Drop the DB schema and alembic version altogether
+drop:
+    PGPASSWORD="$MB__SERVER__POSTGRES__PASSWORD" \
+    psql -h localhost -p "$MB__SERVER__POSTGRES__PORT" \
+    -U "$MB__SERVER__POSTGRES__USER" -d "$MB__SERVER__POSTGRES__DATABASE" -v ON_ERROR_STOP=1 \
+    -c "DROP SCHEMA IF EXISTS mb CASCADE; DROP TABLE IF EXISTS alembic_version;"
+


### PR DESCRIPTION
Occasionally, a local DB state gets out of sync with migrations and we need to manually delete the MB schema and alembic table. This PR automates that.

## 🛠️ Changes proposed in this pull request

* Add `just` command that drops MB schema and `alembic_version` table

## 👀 Guidance to review

None

## 🤖 AI declaration

Helped think the problem through

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
