### PR TITLE
Remove trace for `MatchboxHTTPException`

### DIFF
--- a/src/matchbox/common/exceptions.py
+++ b/src/matchbox/common/exceptions.py
@@ -188,6 +188,29 @@ class MatchboxServerFileError(MatchboxHttpException):
         super().__init__(message)
 
 
+# -- Authentication exceptions --
+
+
+class MatchboxAuthenticationError(MatchboxHttpException):
+    """Authentication failed."""
+
+    http_status = 401
+
+    def __init__(self, message: str | None = None, reason: str | None = None) -> None:
+        """Initialise the exception."""
+        if message is None:
+            message = "Authentication failed."
+
+        super().__init__(message)
+        self.reason = reason
+
+    def to_details(self) -> dict[str, Any] | None:
+        """Return reason if set."""
+        if self.reason is not None:
+            return {"reason": self.reason}
+        return None
+
+
 # -- Resource not found on server exceptions --
 
 

--- a/src/matchbox/server/api/main.py
+++ b/src/matchbox/server/api/main.py
@@ -21,7 +21,6 @@ from fastapi.openapi.docs import (
 )
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
-from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import HTMLResponse
 
 from matchbox.common.arrow import table_to_buffer
@@ -81,7 +80,7 @@ async def matchbox_exception_handler(
     )
 
 
-@app.exception_handler(StarletteHTTPException)
+@app.exception_handler(Exception)
 async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Handler for unexpected exceptions to ensure consistent error responses."""
     error_id = str(uuid.uuid4())

--- a/src/matchbox/server/api/routers/auth.py
+++ b/src/matchbox/server/api/routers/auth.py
@@ -4,9 +4,9 @@ import json
 from typing import Annotated
 
 from fastapi import APIRouter, Security
-from fastapi.exceptions import HTTPException
 
 from matchbox.common.dtos import AuthStatusResponse, User
+from matchbox.common.exceptions import MatchboxAuthenticationError
 from matchbox.server.api.dependencies import (
     JWT_HEADER,
     BackendDependency,
@@ -78,7 +78,7 @@ async def authentication_status(
             username=username,
             token=token,
         )
-    except HTTPException:
+    except MatchboxAuthenticationError:
         # JWT validation failed
         return AuthStatusResponse(
             authenticated=False,


### PR DESCRIPTION
https://github.com/uktrade/matchbox/pull/429 refactored the way exceptions are transferred from server to client and introduced issue where normally handled exceptions leading to e.g. a 404 where spamming stack traces to the API logs.

## 🛠️ Changes proposed in this pull request

* Handle `MatchboxHTTPException` directly, before they reach the Starlette layer and get re-raised
* Align API auth errors with the pattern used in the rest of the API

## 👀 Guidance to review

NA

## 🤖 AI declaration

Modified the errors raised by the auth validator.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
