### PR TITLE
Added type checking with ty

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,7 +29,7 @@ echo "MB__CLIENT__JWT=$(jq -r .private_key /tmp/keys.json | \
     tr -d '\n')" >> .env
 ```
 
-This project is managed by [uv](https://docs.astral.sh/uv/), linted and formated with [ruff](https://docs.astral.sh/ruff/), and tested with [pytest](https://docs.pytest.org/en/stable/). [Docker](https://www.docker.com) is used for local development. Documentation is build using [mkdocs](https://www.mkdocs.org).
+This project is managed by [uv](https://docs.astral.sh/uv/), linted and formated with [ruff](https://docs.astral.sh/ruff/), type checked with [ty](https://docs.astral.sh/ty/), and tested with [pytest](https://docs.pytest.org/en/stable/). [Docker](https://www.docker.com) is used for local development. Documentation is build using [mkdocs](https://www.mkdocs.org).
 
 To install all dependencies for this project, run:
 
@@ -167,7 +167,7 @@ When contributing to the main matchbox repository and its associated repos, we t
 * Unit tested, and pass new and existing tests
 * Documented via docstrings, in the [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
 * Linted and auto-formatted (`just format`)
-* Type hinted (within reason)
+* Type hinted and checked (`just check`)
 * Using env files and dotenv for setting environment variables
 * Structured as a Python package with `pyprojects.toml`
 * Using dependencies managed automatically by uv

--- a/justfile
+++ b/justfile
@@ -24,6 +24,10 @@ format:
     uvx ruff@latest check . --fix
     uvx uv-sort pyproject.toml
 
+# Run type checking
+check:
+    uvx ty@latest check --output-format concise
+
 # Scan for secrets
 scan:
     bash -c "docker run -v "$(pwd):/repo" -i \


### PR DESCRIPTION
Adds type checking using [ty](https://docs.astral.sh/ty/).

Closes #413 

Progress: **0**/1,187

## 🛠️ Changes proposed in this pull request

See individual PRs for details.

## 👀 Guidance to review

See individual PRs for details.

## 🤖 AI declaration

Heavy AI use for rote and boilerplate changes. Also used for ideation of specific changes. 

All human reviewed.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
