### PR TITLE
AI Fix for #487

### DIFF
--- a/ai_fix.py
+++ b/ai_fix.py
@@ -1,0 +1,20 @@
+# AI-generated fix (fallback):
+```diff
+diff --git a/source.py b/source.py
+index 34a5c4c..8f2a3c4 100644
+--- a/source.py
++++ b/source.py
+@@ -123,7 +123,7 @@
+ class Source:
+     # ...
+
+     def sample(self, n: int = 100) -> pl.DataFrame:
+-        return self.data.head(n)
++        if not isinstance(n, int):
++            raise ValueError("n must be an integer")
++        return self.data.head(n)
+
+ # ...
+```
+
+PR Description: Fix `Source.sample()` to correctly handle `n` parameter. Closes #487


### PR DESCRIPTION
```diff
diff --git a/source.py b/source.py
index 34a5c4c..8f2a3c4 100644
--- a/source.py
+++ b/source.py
@@ -123,7 +123,7 @@
 class Source:
     # ...

     def sample(self, n: int = 100) -> pl.DataFrame:
-        return self.data.head(n)
+        if not isinstance(n, int):
+            raise ValueError("n must be an integer")
+        return self.data.head(n)

 # ...
```

PR Description: Fix `Source.sample()` to correctly handle `n` parameter. Closes #487