### PR TITLE
Get dependabot to group its PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Get dependabot to [group its PRs by ecosystem](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--), to reduce PR noise.

## 🛠️ Changes proposed in this pull request

Changed `dependabot.yml`.

## 👀 Guidance to review

To pick a random repo, [this config](https://redirect.github.com/ReactiveX/RxPY/blob/4247d86a51796559eda1c7a2452e1745912eadb9/.github/dependabot.yml#L4) made [this PR](https://redirect.github.com/ReactiveX/RxPY/pull/772).

## 🤖 AI declaration

AI written, human reviewed.

## ✅ Checklist:

- [ ] This is the smallest, simplest solution to the problem
- [ ] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [ ] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
