### PR TITLE
Fixed Alembic path bug so Matchbox imports correctly

### DIFF
--- a/src/matchbox/server/postgresql/alembic.ini
+++ b/src/matchbox/server/postgresql/alembic.ini
@@ -1,7 +1,7 @@
 [alembic]
-script_location = src/matchbox/server/postgresql/alembic
+script_location = %(here)s/alembic
 prepend_sys_path = .
-version_locations = src/matchbox/server/postgresql/alembic/versions
+version_locations = %(here)s/alembic/versions
 path_separator = os
 revision_environment = true
 

--- a/src/matchbox/server/postgresql/db.py
+++ b/src/matchbox/server/postgresql/db.py
@@ -38,7 +38,7 @@ class MatchboxPostgresCoreSettings(BaseModel):
     database: str
     db_schema: str
     alembic_config: Path = Field(
-        default=Path("src/matchbox/server/postgresql/alembic.ini")
+        default=Path(__file__).resolve().with_name("alembic.ini")
     )
 
     def get_alembic_config(self) -> Config:


### PR DESCRIPTION
It's hard to import Matchbox and use it as a library if you want to deploy the API because Alembic paths are hard coded.

Fixes #579 

## 🛠️ Changes proposed in this pull request

Makes all Alembic paths relative, allowing import.

## 👀 Guidance to review

If this wasn't fixed, this would fail:

```
willlangdale@DBT001350 ~/D/matchbox (bug/alembic-path) [1]> uv run python -c "from pathlib import Path; import matchbox.server.postgresql
.db as m; print(Path(m.__file__).with_name('alembic.ini').exists())"
True
```

## 🤖 AI declaration

Ideated with an LLM, fixed by hand.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [ ] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
