### PR TITLE
Alembic always migrates

### DIFF
--- a/src/matchbox/client/queries.py
+++ b/src/matchbox/client/queries.py
@@ -201,7 +201,9 @@ class Query:
                 raw_data = raw_data.group_by("id").agg(pl.all().exclude("id").unique())
             if self.config.combine_type == QueryCombineType.EXPLODE:
                 raw_data = raw_data.group_by("id").agg(pl.all().exclude("id"))
-                raw_data = raw_data.explode(pl.all().exclude("id")).unique()
+                raw_data = raw_data.explode(
+                    pl.all().exclude("id"), empty_as_null=True
+                ).unique()
 
             return _convert_df(raw_data.collect(), return_type=return_type)
 

--- a/src/matchbox/common/hash.py
+++ b/src/matchbox/common/hash.py
@@ -208,7 +208,7 @@ def hash_arrow_table(
     # Explode list fields
     for column in columns:
         if isinstance(df.schema[column], pl.List):
-            df = df.explode(column)
+            df = df.explode(column, empty_as_null=True)
 
     df = df.sort(by=columns)
     row_hashes = hash_rows(df=df, columns=columns, method=method)
@@ -242,7 +242,7 @@ def hash_clusters(assignments: pa.Table) -> bytes:
         .select("child_ids")
         .sort("child_ids")
         .with_row_index(name="cluster_ordinal", offset=1)
-        .explode("child_ids")
+        .explode("child_ids", empty_as_null=True)
         .rename({"child_ids": "child_id"})
         .cast(
             {

--- a/src/matchbox/server/postgresql/db.py
+++ b/src/matchbox/server/postgresql/db.py
@@ -17,7 +17,6 @@ from sqlalchemy import (
     MetaData,
     Table,
     create_engine,
-    inspect,
     text,
 )
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
@@ -197,23 +196,8 @@ class MatchboxDatabase:
             pool.close()
 
     def run_migrations(self) -> None:
-        """Create the database and all tables expected in the schema."""
-        alembic_version = self._look_for_alembic_version()
-        engine = self.get_engine()
-        schema = self.settings.postgres.db_schema
-        if alembic_version is not None:
-            logger.info("Determinded alembic in use so upgrading to head")
-            command.upgrade(self.alembic_config, "head")
-        else:
-            logger.info(
-                "Determinded alembic not in use so dropping schema if it "
-                "exists prior to upgrading to head. "
-            )
-            with engine.connect() as conn:
-                conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE;"))
-                conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema};"))
-                conn.commit()
-            command.upgrade(self.alembic_config, "head")
+        """Create or migrate all tables expected in the schema."""
+        command.upgrade(self.alembic_config, "head")
 
     def clear_database(self) -> None:
         """Delete all rows in every table in the database schema.
@@ -293,22 +277,6 @@ class MatchboxDatabase:
                     conn.execute(text(f"VACUUM ANALYZE {table_name};"))
             else:
                 conn.execute(text("VACUUM ANALYZE;"))
-
-    def _look_for_alembic_version(self) -> bool:
-        engine = self.get_engine()
-        inspector = inspect(engine)
-        alembic_version_table = "alembic_version" in inspector.get_table_names(
-            schema="public"
-        )
-        if alembic_version_table:
-            with engine.connect() as conn:
-                result = conn.execute(
-                    text("SELECT version_num FROM public.alembic_version;")
-                )
-                alembic_version = result.scalar()
-        else:
-            alembic_version = None
-        return alembic_version
 
     @property
     def sorted_tables(self) -> list[Table]:

--- a/test/fixtures/db.py
+++ b/test/fixtures/db.py
@@ -37,6 +37,7 @@ WAREHOUSE_PASSWORD = "warehouse_password"
 
 
 def _worker_database_name(prefix: str, worker_id: str) -> str:
+    "Generate a worker name."
     return f"{prefix}_test_{worker_id}"
 
 
@@ -46,6 +47,7 @@ def _postgres_url(
     port: int,
     database: str,
 ) -> str:
+    """Shape a PostgreSQL URL."""
     return f"postgresql+psycopg://{user}:{password}@{POSTGRES_HOST}:{port}/{database}"
 
 
@@ -55,6 +57,7 @@ def _drop_database(
     port: int,
     database: str,
 ) -> None:
+    """Drop the specified database."""
     maintenance_engine = create_engine(
         _postgres_url(user, password, port, "postgres"),
         isolation_level="AUTOCOMMIT",
@@ -82,6 +85,7 @@ def _drop_database(
 
 
 def _recreate_database(user: str, password: str, port: int, database: str) -> None:
+    """Create a fresh database."""
     _drop_database(user, password, port, database)
     maintenance_engine = create_engine(
         _postgres_url(user, password, port, "postgres"),
@@ -93,6 +97,19 @@ def _recreate_database(user: str, password: str, port: int, database: str) -> No
             connection.execute(text(f'CREATE DATABASE "{database}"'))
     finally:
         maintenance_engine.dispose()
+
+
+def _create_schema(
+    user: str, password: str, port: int, database: str, schema: str
+) -> None:
+    """Create the Matchbox schema in a database."""
+    engine = create_engine(_postgres_url(user, password, port, database))
+    try:
+        with engine.connect() as connection:
+            connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+            connection.commit()
+    finally:
+        engine.dispose()
 
 
 class DevelopmentSettings(BaseSettings):
@@ -329,6 +346,10 @@ def worker_matchbox_postgres(
         development_settings=development_settings,
         matchbox_datastore=matchbox_datastore,
         database=database,
+    )
+
+    _create_schema(
+        MATCHBOX_USER, MATCHBOX_PASSWORD, port, database, settings.postgres.db_schema
     )
 
     try:


### PR DESCRIPTION
When we removed schema management in #590 we left in a place to create the schema which flouts the "db manager creates the schema" rule: when migrations run for the first time.

## 🛠️ Changes proposed in this pull request

* Removes that line then fixes tests that need the schema.
* Adds some docstrings cause I like 'em.
* Deals with a warning that polars is about to change the default arg for `explode(empty_as_null)` by making the default value explicit

## 👀 Guidance to review

None.

## 🤖 AI declaration

Ideated with AI. Implemented by hand.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
