### PR TITLE
Remove management of pg extensions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -87,13 +87,13 @@ just test
 ```
 
 
-## Database Migrations for PostgreSQL backend
+## Database migrations for PostgreSQL backend
 
 Migrations for the PostgreSQL backend are managed by [Alembic](https://alembic.sqlalchemy.org/en/latest/).
 
 !!! warning
 
-    Do not make alternations to the database using mechanisms other then Alembic. This will interfere with the migration scripts.
+    Migrations must only manage tables. Creating the schema itself, or PostgreSQL extensions, is an operator/DBA responsibility (see [Installation](server/install.md#database-schema-and-extensions)), not something a migration should do.
 
 If:
 

--- a/docs/server/install.md
+++ b/docs/server/install.md
@@ -18,15 +18,17 @@ At a minimum, you will need to provision the following infrastructure:
 * The main Matchbox database (like Postgres)
 * A bucket in object storage (like S3)
 
-### Database schema
+### Database setup
 
-Before running migrations, the PostgreSQL schema must exist. Create it once with:
+Before running migrations, the PostgreSQL schema must exist, and the extensions Matchbox depends on must be installed. Create them once with:
 
 ```sql
 CREATE SCHEMA IF NOT EXISTS mb;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 ```
 
-Replace `mb` with the value of `MB__SERVER__POSTGRES__DB_SCHEMA` if you are using a custom schema name. The local development `docker-compose.yml` handles this automatically via an init script.
+Replace `mb` with the value of `MB__SERVER__POSTGRES__DB_SCHEMA` if you are using a custom schema name.
 
 This requires that the processing of files uploaded by clients happens on the same instance as the API. Thus, it is not advised to run the Matchbox server in this fashion, except for development or very small setups. The Matchbox server variable `MB__SERVER__TASK_RUNNER` needs to be set to "api" for this minimal setup.
 

--- a/src/matchbox/server/postgresql/alembic/versions/40a8e5ed48f2_create_schema_without_tables.py
+++ b/src/matchbox/server/postgresql/alembic/versions/40a8e5ed48f2_create_schema_without_tables.py
@@ -6,6 +6,7 @@ Revises: This is the first migration
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -15,16 +16,42 @@ down_revision: str | None = None
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+REQUIRED_EXTENSIONS = ("uuid-ossp", "pgcrypto")
+
 
 def upgrade() -> None:
-    """Upgrade schema."""
-    # Schema must be created by the operator before running migrations.
-    op.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
-    op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto"')
+    """Verify the operator has provisioned the schema and required extensions.
+
+    See see docs/server/install.md for more information.
+    """
+    schema = op.get_context().config.get_main_option("db_schema")
+    connection = op.get_bind()
+
+    schema_exists = connection.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.schemata WHERE schema_name = :schema"
+        ),
+        {"schema": schema},
+    ).scalar()
+    if not schema_exists:
+        raise RuntimeError(
+            f'Schema "{schema}" does not exist. It must be created by the '
+            "operator before running migrations (see docs/server/install.md)."
+        )
+
+    for extension in REQUIRED_EXTENSIONS:
+        extension_installed = connection.execute(
+            sa.text("SELECT 1 FROM pg_extension WHERE extname = :extension"),
+            {"extension": extension},
+        ).scalar()
+        if not extension_installed:
+            raise RuntimeError(
+                f'Extension "{extension}" is not installed. It must be created '
+                "by the operator before running migrations "
+                "(see docs/server/install.md)."
+            )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    # Schema lifecycle is managed by the operator, not migrations.
-    op.execute('DROP EXTENSION IF EXISTS "uuid-ossp"')
-    op.execute('DROP EXTENSION IF EXISTS "pgcrypto"')
+    # No-op: schema and extension lifecycle is managed by the operator, not migrations.

--- a/test/fixtures/db.py
+++ b/test/fixtures/db.py
@@ -112,6 +112,18 @@ def _create_schema(
         engine.dispose()
 
 
+def _create_extensions(user: str, password: str, port: int, database: str) -> None:
+    """Create the PostgreSQL extensions Matchbox requires in a database."""
+    engine = create_engine(_postgres_url(user, password, port, database))
+    try:
+        with engine.connect() as connection:
+            connection.execute(text('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'))
+            connection.execute(text('CREATE EXTENSION IF NOT EXISTS "pgcrypto"'))
+            connection.commit()
+    finally:
+        engine.dispose()
+
+
 class DevelopmentSettings(BaseSettings):
     api_port: int = 8000
     datastore_console_port: int = 9003
@@ -351,6 +363,7 @@ def worker_matchbox_postgres(
     _create_schema(
         MATCHBOX_USER, MATCHBOX_PASSWORD, port, database, settings.postgres.db_schema
     )
+    _create_extensions(MATCHBOX_USER, MATCHBOX_PASSWORD, port, database)
 
     try:
         with MBDB.settings_scope(settings):

--- a/test/scripts/postgres/postgres-create-schema.sh
+++ b/test/scripts/postgres/postgres-create-schema.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-# Creates the Matchbox PostgreSQL schema on first container startup.
-# Mounted into /docker-entrypoint-initdb.d/ by docker-compose so postgres
-# runs it once when initialising a fresh data volume.
+# Creates the Matchbox PostgreSQL schema and extensions on first container
+# startup. Mounted into /docker-entrypoint-initdb.d/ by docker-compose so
+# postgres runs it once when initialising a fresh data volume.
+#
+# These are operator responsibilities in production (see docs/server/install.md).
+# This script automates them for local dev/CI only.
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
     CREATE SCHEMA IF NOT EXISTS ${MB__SERVER__POSTGRES__DB_SCHEMA:-mb};
+    CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 EOSQL


### PR DESCRIPTION
In order to respect the new philosophical direction in #590 and #605, we need to remove extension management from the PostgreSQL backend.

## 🛠️ Changes proposed in this pull request

Removes extension management and updates documentation and tests to pick this up.

## 👀 Guidance to review

None.

## 🤖 AI declaration

AI written, human reviewed.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [x] Tutorials
    - [x] Developer docs
