### PR TITLE
Factor common SQL out of backend adapter to enable eventual local adapter

### DIFF
--- a/src/matchbox/common/adapters/__init__.py
+++ b/src/matchbox/common/adapters/__init__.py
@@ -1,0 +1,7 @@
+"""Shared backend adapter contracts and machinery.
+
+Code shared by every Matchbox backend: the cluster store protocol ABC,
+and the SQL machinery that relational backends compose to implement it.
+
+TODO: local client-side backends will depend on this package too.
+"""

--- a/src/matchbox/common/adapters/__init__.py
+++ b/src/matchbox/common/adapters/__init__.py
@@ -2,6 +2,4 @@
 
 Code shared by every Matchbox backend: the cluster store protocol ABC,
 and the SQL machinery that relational backends compose to implement it.
-
-TODO: local client-side backends will depend on this package too.
 """

--- a/src/matchbox/common/adapters/protocol.py
+++ b/src/matchbox/common/adapters/protocol.py
@@ -1,9 +1,12 @@
 """The cluster store protocol shared by every Matchbox backend."""
 
+import json
 from abc import ABC, abstractmethod
-from typing import Protocol
+from enum import StrEnum
+from typing import Any, Protocol
 
 from pyarrow import Table
+from pydantic import BaseModel, field_validator
 
 from matchbox.common.dtos import (
     Match,
@@ -37,6 +40,29 @@ class ListableAndCountable(Countable, Listable):
     pass
 
 
+class MatchboxBackends(StrEnum):
+    """The available backends for Matchbox."""
+
+    POSTGRES = "postgres"
+
+
+class MatchboxSnapshot(BaseModel):
+    """A snapshot of the Matchbox database."""
+
+    backend_type: MatchboxBackends
+    data: dict[str, Any]
+
+    @field_validator("data")
+    @classmethod
+    def check_serialisable(cls, value: dict[str, Any]) -> dict[str, Any]:
+        """Validate that the value can be serialised to JSON."""
+        try:
+            json.dumps(value)
+            return value
+        except (TypeError, OverflowError) as e:
+            raise ValueError(f"Value is not JSON serialisable: {e}") from e
+
+
 class MatchboxClusterStoreAdapter(ABC):
     """The contract shared by anything that stores and serves cluster data.
 
@@ -50,9 +76,9 @@ class MatchboxClusterStoreAdapter(ABC):
     source_clusters: Countable
     model_clusters: Countable
     all_clusters: Countable
-    creates: Countable
-    merges: Countable
-    proposes: Countable
+    creates: Countable  # clusters proposed by resolver
+    merges: Countable  # cluster lineage tree
+    proposes: Countable  # raw model edge scores
 
     # Query block
 
@@ -143,4 +169,46 @@ class MatchboxClusterStoreAdapter(ABC):
     @abstractmethod
     def get_resolver_data(self, path: ResolverStepPath) -> Table:
         """Get cluster assignments for a resolver step."""
+        ...
+
+    # Data management
+
+    @abstractmethod
+    def dump(self) -> MatchboxSnapshot:
+        """Dumps the entire database to a snapshot.
+
+        Returns:
+            A MatchboxSnapshot with the database's current state, tagged
+                with the backend type that produced it.
+        """
+        ...
+
+    @abstractmethod
+    def restore(self, snapshot: MatchboxSnapshot) -> None:
+        """Restores the database from a snapshot.
+
+        Args:
+            snapshot: A MatchboxSnapshot with the database's state
+
+        Raises:
+            TypeError: If the snapshot's backend type doesn't match this one
+        """
+        ...
+
+    @abstractmethod
+    def clear(self, certain: bool) -> None:
+        """Soft clear the database by deleting all rows but retaining tables.
+
+        Args:
+            certain: Whether to delete the database without confirmation.
+        """
+        ...
+
+    @abstractmethod
+    def drop(self, certain: bool) -> None:
+        """Hard clear the database by dropping all tables and re-creating.
+
+        Args:
+            certain: Whether to drop the database without confirmation.
+        """
         ...

--- a/src/matchbox/common/adapters/protocol.py
+++ b/src/matchbox/common/adapters/protocol.py
@@ -1,0 +1,146 @@
+"""The cluster store protocol shared by every Matchbox backend."""
+
+from abc import ABC, abstractmethod
+from typing import Protocol
+
+from pyarrow import Table
+
+from matchbox.common.dtos import (
+    Match,
+    ModelStepPath,
+    ResolverStepPath,
+    SourceStepPath,
+    Step,
+    StepPath,
+)
+
+
+class Countable(Protocol):
+    """A protocol for objects that can be counted."""
+
+    def count(self) -> int:
+        """Counts the number of items in the object."""
+        ...
+
+
+class Listable(Protocol):
+    """A protocol for objects that can be listed."""
+
+    def list_all(self) -> list[str]:
+        """Lists the items in the object."""
+        ...
+
+
+class ListableAndCountable(Countable, Listable):
+    """A protocol for objects that can be counted and listed."""
+
+    pass
+
+
+class MatchboxClusterStoreAdapter(ABC):
+    """The contract shared by anything that stores and serves cluster data.
+
+    Implemented by MatchboxDBAdapter, and so by the PostgreSQL backend.
+
+    TODO: a local client-side store, backed by an embedded database, will
+    implement this too.
+    """
+
+    # Counts
+    source_clusters: Countable
+    model_clusters: Countable
+    all_clusters: Countable
+    creates: Countable
+    merges: Countable
+    proposes: Countable
+
+    # Query block
+
+    @abstractmethod
+    def query(
+        self,
+        source: SourceStepPath,
+        resolver: ResolverStepPath | None = None,
+        return_leaf_id: bool = False,
+        limit: int | None = None,
+    ) -> Table:
+        """Queries the database from an optional resolution.
+
+        Args:
+            source: The step path identifying the source to query.
+            resolver (optional): The resolver path to use for filtering results.
+                If not specified, the source step is used for the queried source.
+            return_leaf_id (optional): whether to return cluster ID of leaves
+            limit (optional): the number to use in a limit clause. Useful for testing
+
+        Returns:
+            The resulting matchbox IDs in Arrow format
+        """
+        ...
+
+    @abstractmethod
+    def match(
+        self,
+        key: str,
+        source: SourceStepPath,
+        targets: list[SourceStepPath],
+        resolver: ResolverStepPath,
+    ) -> list[Match]:
+        """Match an ID in a source step and return the keys in the targets.
+
+        Args:
+            key: The key to match from the source.
+            source: The path of the source step.
+            targets: The paths of the target source steps.
+            resolver: The resolver path to use for matching.
+        """
+        ...
+
+    # Data block
+
+    @abstractmethod
+    def create_step(self, step: Step, path: StepPath) -> None:
+        """Write a step to Matchbox.
+
+        Args:
+            step: Step object with a source, model, or resolver config
+            path: The step path
+        """
+        ...
+
+    @abstractmethod
+    def insert_source_data(self, path: SourceStepPath, data_hashes: Table) -> None:
+        """Insert hash data for a source step.
+
+        Only possible if data fingerprint matches fingerprint declared when the
+        step was created. Data can only be set once on a step.
+
+        Args:
+            path: The path of the source step to index.
+            data_hashes: The Arrow table with the hash of each data row
+        """
+        ...
+
+    @abstractmethod
+    def insert_model_data(self, path: ModelStepPath, results: Table) -> None:
+        """Insert results data for a model step.
+
+        Only possible if data fingerprint matches fingerprint declared when the
+        step was created. Data can only be set once on a step.
+        """
+        ...
+
+    @abstractmethod
+    def insert_resolver_data(self, path: ResolverStepPath, data: Table) -> None:
+        """Insert resolver cluster assignments for a resolver step."""
+        ...
+
+    @abstractmethod
+    def get_model_data(self, path: ModelStepPath) -> Table:
+        """Get the results for a model step."""
+        ...
+
+    @abstractmethod
+    def get_resolver_data(self, path: ResolverStepPath) -> Table:
+        """Get cluster assignments for a resolver step."""
+        ...

--- a/src/matchbox/common/adapters/sql/__init__.py
+++ b/src/matchbox/common/adapters/sql/__init__.py
@@ -1,0 +1,5 @@
+"""Shared SQL machinery for relational Matchbox backends.
+
+Dialect-neutral Core table metadata, query and match builders, and
+resolver canonicalisation logic for the five cluster tables.
+"""

--- a/src/matchbox/common/adapters/sql/__init__.py
+++ b/src/matchbox/common/adapters/sql/__init__.py
@@ -1,5 +1,5 @@
 """Shared SQL machinery for relational Matchbox backends.
 
 Dialect-neutral Core table metadata, query and match builders, and
-resolver canonicalisation logic for the five cluster tables.
+resolver canonicalisation logic for the cluster tables.
 """

--- a/src/matchbox/common/adapters/sql/query.py
+++ b/src/matchbox/common/adapters/sql/query.py
@@ -1,0 +1,199 @@
+"""Query and match builders, shared across relational backends.
+
+These functions build SQL statements from a pre-computed lineage: an
+ordered list of (step_id, source_config_id) tuples, highest priority
+first, rather than deriving it themselves from a live database. Callers
+resolve lineage however suits their engine and pass the result in.
+
+An entry with no source_config_id is a resolver node. The rest are
+sources. Priority is encoded by list order, highest first.
+"""
+
+from typing import Literal
+
+from sqlalchemy import and_, func, join, select
+from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy.sql.selectable import CTE, Select, Subquery
+
+from matchbox.common.adapters.sql import tables
+
+
+def build_unified_query(
+    lineage: list[tuple[int, int | None]],
+    level: Literal["leaf", "key"] = "leaf",
+    include_source_config_id: bool = False,
+) -> Select:
+    """Build a query that projects records to root IDs through the hierarchy.
+
+    Args:
+        lineage: Ordered (step_id, source_config_id) tuples, highest
+            priority first.
+        level: "leaf" deduplicates to one row per leaf cluster. "key" adds
+            the source key, producing one row per (leaf, key) pair.
+        include_source_config_id: whether to include the source config ID
+            in the selection.
+    """
+    # Separate lineage entries into resolver steps and source config IDs.
+    # Entries without a source_config_id are resolver nodes, the rest are sources
+    resolver_ids: list[int] = []
+    source_config_ids: list[int] = []
+    for step_id, source_config_id in lineage:
+        if source_config_id is None:
+            resolver_ids.append(step_id)
+        else:
+            source_config_ids.append(source_config_id)
+
+    # cluster_keys is the base table, resolver subqueries are LEFT JOINed onto it
+    from_clause = tables.ClusterSourceKey
+    projected_roots: list[ColumnElement[int]] = []
+
+    for resolver_id in resolver_ids:
+        # For each resolver, build a subquery that maps leaf cluster IDs to their
+        # root cluster IDs at that step level via the contains table.
+        assignments: Subquery = (
+            select(
+                tables.Contains.c.leaf.label("leaf_id"),
+                tables.Contains.c.root.label("root_id"),
+            )
+            .select_from(tables.Contains)
+            .join(
+                tables.ResolverClusters,
+                and_(
+                    tables.ResolverClusters.c.cluster_id == tables.Contains.c.root,
+                    tables.ResolverClusters.c.step_id == resolver_id,
+                ),
+            )
+            .subquery(f"resolver_assignments_{resolver_id}")
+        )
+        # LEFT JOIN so that records not claimed by this resolver are still returned
+        from_clause = join(
+            from_clause,
+            assignments,
+            assignments.c.leaf_id == tables.ClusterSourceKey.c.cluster_id,
+            isouter=True,
+        )
+        projected_roots.append(assignments.c.root_id)
+
+    # COALESCE across all resolver root columns
+    # First non-null wins, giving higher-priority resolvers precedence
+    # Falls back to the source cluster ID when no resolver has claimed the record
+    root_projection: ColumnElement[int] = (
+        func.coalesce(*projected_roots, tables.ClusterSourceKey.c.cluster_id)
+        if projected_roots
+        else tables.ClusterSourceKey.c.cluster_id
+    )
+
+    selection: list[ColumnElement] = [
+        root_projection.label("root_id"),
+        tables.ClusterSourceKey.c.cluster_id.label("leaf_id"),
+    ]
+    if level == "key":
+        # "key" level adds the source key, producing more rows than "leaf" because
+        # multiple keys can share the same leaf cluster
+        selection.append(tables.ClusterSourceKey.c.key)
+    if include_source_config_id:
+        selection.append(
+            tables.ClusterSourceKey.c.source_config_id.label("source_config_id")
+        )
+
+    query_stmt = (
+        select(*selection)
+        .select_from(from_clause)
+        .where(tables.ClusterSourceKey.c.source_config_id.in_(source_config_ids))
+    )
+
+    # At "leaf" level, deduplicate rows introduced because multiple keys share
+    # the same leaf cluster
+    if level == "leaf":
+        query_stmt = query_stmt.distinct()
+
+    return query_stmt
+
+
+def build_target_cluster_cte(
+    key: str,
+    source_config_id: int,
+    lineage: list[tuple[int, int | None]],
+) -> CTE:
+    """Build the target cluster CTE for a source key."""
+    # Reuse the unified query at key level, filtered to this source config,
+    # so we get the resolved root cluster for the given key
+    source_projection = build_unified_query(
+        lineage=lineage,
+        level="key",
+        include_source_config_id=True,
+    ).subquery("source_projection")
+
+    return (
+        select(source_projection.c.root_id.label("cluster_id"))
+        .where(
+            and_(
+                source_projection.c.source_config_id == source_config_id,
+                source_projection.c.key == key,
+            )
+        )
+        # Exactly one cluster per key
+        # LIMIT 1 avoids a redundant scan
+        .limit(1)
+        .cte("target_cluster")
+    )
+
+
+def build_matching_leaves_cte(
+    source_and_target_ids: list[int],
+    lineage: list[tuple[int, int | None]],
+    target_cluster_cte: CTE,
+) -> CTE:
+    """Build the matching keys CTE for a resolved cluster."""
+    # Project all source + target keys through the hierarchy, then filter to those
+    # whose resolved root matches the target cluster
+    full_projection = build_unified_query(
+        lineage=lineage,
+        level="key",
+        include_source_config_id=True,
+    ).subquery("full_projection")
+
+    return (
+        select(
+            full_projection.c.root_id.label("cluster_id"),
+            full_projection.c.source_config_id,
+            full_projection.c.key,
+        )
+        .where(
+            and_(
+                full_projection.c.source_config_id.in_(source_and_target_ids),
+                full_projection.c.root_id == target_cluster_cte.c.cluster_id,
+            )
+        )
+        .distinct()
+        .cte("matching_leaves")
+    )
+
+
+def resolver_membership_subquery(
+    step_id: int,
+    alias: str = "resolver_membership",
+) -> Subquery:
+    """Build root_id/leaf_id membership rows for a resolver."""
+    # First branch: root clusters count as their own leaf (self-membership)
+    roots_query = select(
+        tables.ResolverClusters.c.cluster_id.label("root_id"),
+        tables.ResolverClusters.c.cluster_id.label("leaf_id"),
+    ).where(tables.ResolverClusters.c.step_id == step_id)
+
+    # Second branch: all clusters contained within a root via the contains table
+    leaves_query = (
+        select(
+            tables.ResolverClusters.c.cluster_id.label("root_id"),
+            tables.Contains.c.leaf.label("leaf_id"),
+        )
+        .select_from(tables.ResolverClusters)
+        .join(
+            tables.Contains,
+            tables.Contains.c.root == tables.ResolverClusters.c.cluster_id,
+        )
+        .where(tables.ResolverClusters.c.step_id == step_id)
+    )
+
+    # UNION deduplicates in case a root cluster also appears as a leaf
+    return roots_query.union(leaves_query).subquery(alias)

--- a/src/matchbox/common/adapters/sql/resolver.py
+++ b/src/matchbox/common/adapters/sql/resolver.py
@@ -1,0 +1,89 @@
+"""Resolver cluster canonicalisation, shared across relational backends.
+
+Expanding a resolver's incoming (parent_id, child_id) assignments to their
+leaf-level cluster IDs, and deriving a single composite hash per parent
+cluster from its sorted leaf hashes, so identical parent clusters dedupe to
+one row regardless of which backend computed them.
+"""
+
+from collections.abc import Iterable
+
+import pyarrow as pa
+from sqlalchemy import Row, func, select
+from sqlalchemy.sql.expression import TableClause
+from sqlalchemy.sql.selectable import Select, Subquery
+
+from matchbox.common.adapters.sql import tables
+from matchbox.common.transform import hash_cluster_leaves
+
+
+def build_expanded_leaves_subquery(
+    incoming_cluster_assignments: TableClause,
+) -> Subquery:
+    """Expand child assignments to leaf-level cluster IDs per parent cluster."""
+    return (
+        select(
+            incoming_cluster_assignments.c.parent_id,
+            func.coalesce(
+                tables.Contains.c.leaf,
+                incoming_cluster_assignments.c.child_id,
+            ).label("leaf_id"),
+        )
+        .distinct()
+        .select_from(
+            # Clusters with no children in contains resolve to themselves
+            incoming_cluster_assignments.outerjoin(
+                tables.Contains,
+                tables.Contains.c.root == incoming_cluster_assignments.c.child_id,
+            )
+        )
+        .subquery("expanded_leaves")
+    )
+
+
+def build_leaf_hash_groups_query(expanded_leaves: Subquery) -> Select:
+    """Build a query grouping leaf hashes per parent cluster.
+
+    Uses an inner join to the clusters table, so unknown leaf IDs are
+    silently dropped here. Callers relying on validation should catch this
+    downstream, for example as FK violations when inserting into contains.
+    """
+    return (
+        select(
+            expanded_leaves.c.parent_id,
+            func.array_agg(tables.Clusters.c.cluster_hash).label("leaf_hashes"),
+        )
+        .select_from(
+            expanded_leaves.join(
+                tables.Clusters,
+                tables.Clusters.c.cluster_id == expanded_leaves.c.leaf_id,
+            )
+        )
+        .group_by(expanded_leaves.c.parent_id)
+    )
+
+
+def hash_resolver_parents(
+    rows: Iterable[Row],
+) -> pa.Table:
+    """Compute a single composite hash per parent cluster from leaf hashes.
+
+    Args:
+        rows: (parent_id, leaf_hashes) rows, as returned by executing
+            build_leaf_hash_groups_query.
+
+    Returns:
+        Arrow table with columns (parent_id: int64, cluster_hash: binary).
+    """
+    parent_ids: list[int] = []
+    cluster_hashes: list[bytes] = []
+    for parent_id, leaf_hashes in rows:
+        parent_ids.append(int(parent_id))
+        cluster_hashes.append(hash_cluster_leaves([bytes(h) for h in leaf_hashes]))
+
+    return pa.table(
+        {
+            "parent_id": parent_ids,
+            "cluster_hash": cluster_hashes,
+        }
+    )

--- a/src/matchbox/common/adapters/sql/tables.py
+++ b/src/matchbox/common/adapters/sql/tables.py
@@ -42,7 +42,7 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 
-metadata = MetaData(schema="mb")
+METADATA = MetaData(schema="mb")
 """Shared metadata for the five cluster tables.
 
 schema="mb" is a symbolic token, translated to a real schema, or none, by
@@ -52,7 +52,7 @@ literal schema name.
 
 Clusters = Table(
     "clusters",
-    metadata,
+    METADATA,
     Column("cluster_id", BigInteger, primary_key=True),
     Column("cluster_hash", LargeBinary, nullable=False),
     UniqueConstraint("cluster_hash", name="clusters_hash_key"),
@@ -61,7 +61,7 @@ Clusters = Table(
 
 ClusterSourceKey = Table(
     "cluster_keys",
-    metadata,
+    METADATA,
     Column("key_id", BigInteger, primary_key=True),
     Column(
         "cluster_id",
@@ -85,7 +85,7 @@ ClusterSourceKey = Table(
 
 Contains = Table(
     "contains",
-    metadata,
+    METADATA,
     Column(
         "root",
         BigInteger,
@@ -107,7 +107,7 @@ Contains = Table(
 
 ModelEdges = Table(
     "model_edges",
-    metadata,
+    METADATA,
     Column("result_id", BigInteger, primary_key=True, autoincrement=True),
     Column(
         "step_id",
@@ -139,7 +139,7 @@ Stores the raw left/right scores created by a model.
 
 ResolverClusters = Table(
     "resolver_clusters",
-    metadata,
+    METADATA,
     Column(
         "step_id",
         BigInteger,

--- a/src/matchbox/common/adapters/sql/tables.py
+++ b/src/matchbox/common/adapters/sql/tables.py
@@ -1,0 +1,157 @@
+"""Shared Core table metadata for the five cluster tables.
+
+Follows the declarative with imperative table pattern: these are plain
+SQLAlchemy Core Table objects on one shared MetaData, used directly by
+every backend. Relational backends adopt them via __table__ on their own
+ORM classes, or use them as-is with Core.
+
+Rules for this module:
+
+- Generic types only (BigInteger, LargeBinary, Text, REAL). No
+    dialect-specific types, no native enums. If a column genuinely needs a
+    dialect type, use type.with_variant(PGType, "postgresql") on the shared
+    column rather than forking the definition.
+- The schema is the symbolic token "mb", never rendered literally. Each
+    consuming engine resolves it to a real schema, or none, via
+    execution_options(schema_translate_map={"mb": ...}). See
+    matchbox.server.postgresql.db for the server-side wiring.
+- Postgres-only indexes and ingest DDL stay in the server package, not here.
+
+Names match each backend's ORM class exactly (Clusters, ClusterSourceKey,
+Contains, ModelEdges, ResolverClusters), so import this module and
+reference tables.Clusters rather than importing names directly. These are
+Table instances, not classes: the PascalCase name signals the pairing,
+not that they can be subclassed or instantiated.
+
+TODO: once a second backend exists, add dedicated tests for this module
+and the rest of matchbox.common.adapters.sql, rather than relying solely
+on the PostgreSQL adapter test suite.
+"""
+
+from sqlalchemy import (
+    REAL,
+    BigInteger,
+    CheckConstraint,
+    Column,
+    ForeignKey,
+    Index,
+    LargeBinary,
+    MetaData,
+    Table,
+    Text,
+    UniqueConstraint,
+)
+
+metadata = MetaData(schema="mb")
+"""Shared metadata for the five cluster tables.
+
+schema="mb" is a symbolic token, translated to a real schema, or none, by
+each consuming engine via schema_translate_map. Never rendered as a
+literal schema name.
+"""
+
+Clusters = Table(
+    "clusters",
+    metadata,
+    Column("cluster_id", BigInteger, primary_key=True),
+    Column("cluster_hash", LargeBinary, nullable=False),
+    UniqueConstraint("cluster_hash", name="clusters_hash_key"),
+)
+"""Table of indexed data and clusters that match it."""
+
+ClusterSourceKey = Table(
+    "cluster_keys",
+    metadata,
+    Column("key_id", BigInteger, primary_key=True),
+    Column(
+        "cluster_id",
+        BigInteger,
+        ForeignKey("clusters.cluster_id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column(
+        "source_config_id",
+        BigInteger,
+        ForeignKey("source_configs.source_config_id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("key", Text, nullable=False),
+    Index("ix_cluster_keys_cluster_id", "cluster_id"),
+    Index("ix_cluster_keys_keys", "key"),
+    Index("ix_cluster_keys_source_config_id", "source_config_id"),
+    UniqueConstraint("key_id", "source_config_id", name="unique_keys_source"),
+)
+"""Table for storing source primary keys for clusters."""
+
+Contains = Table(
+    "contains",
+    metadata,
+    Column(
+        "root",
+        BigInteger,
+        ForeignKey("clusters.cluster_id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "leaf",
+        BigInteger,
+        ForeignKey("clusters.cluster_id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    CheckConstraint("root != leaf", name="no_self_containment"),
+    UniqueConstraint("root", "leaf"),
+    Index("ix_contains_root_leaf", "root", "leaf"),
+    Index("ix_contains_leaf_root", "leaf", "root"),
+)
+"""Cluster lineage table."""
+
+ModelEdges = Table(
+    "model_edges",
+    metadata,
+    Column("result_id", BigInteger, primary_key=True, autoincrement=True),
+    Column(
+        "step_id",
+        BigInteger,
+        ForeignKey("steps.step_id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column(
+        "left_id",
+        BigInteger,
+        ForeignKey("clusters.cluster_id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column(
+        "right_id",
+        BigInteger,
+        ForeignKey("clusters.cluster_id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("score", REAL, nullable=False),
+    Index("ix_model_edges_step", "step_id"),
+    CheckConstraint("score >= 0.0 AND score <= 1.0", name="valid_score"),
+    UniqueConstraint("step_id", "left_id", "right_id"),
+)
+"""Table of results for a model step.
+
+Stores the raw left/right scores created by a model.
+"""
+
+ResolverClusters = Table(
+    "resolver_clusters",
+    metadata,
+    Column(
+        "step_id",
+        BigInteger,
+        ForeignKey("steps.step_id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "cluster_id",
+        BigInteger,
+        ForeignKey("clusters.cluster_id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Index("ix_resolver_clusters_step", "step_id"),
+)
+"""Association table linking resolver steps to cluster IDs."""

--- a/src/matchbox/common/factories/scenarios.py
+++ b/src/matchbox/common/factories/scenarios.py
@@ -199,26 +199,34 @@ def create_preindex_scenario(
     The warehouse contains three interlinked tables that cover common linkage
     realistic scenarios, but are not yet indexed.
     """
-    # First create the admin scenario
-    dag_testkit = create_admin_scenario(
+    # First create the bare scenario
+    dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
     )
 
-    # Set default public permissions
-    default_permissions: list[PermissionGrant] = [
-        PermissionGrant(
-            group_name=GroupName(DefaultGroup.PUBLIC), permission=PermissionType.READ
-        ),
-        PermissionGrant(
-            group_name=GroupName(DefaultGroup.PUBLIC), permission=PermissionType.WRITE
-        ),
-    ]
+    # Server-only: local backends have no users, collections, or runs
+    if isinstance(backend, MatchboxDBAdapter):
+        # First user is admin
+        response = backend.login(User(user_name="alice", email="alice@example.org"))
+        assert response.setup_mode_admin
 
-    # Create collection and run
-    backend.create_collection(
-        name=dag_testkit.dag.name, permissions=default_permissions
-    )
-    dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+        # Set default public permissions
+        default_permissions: list[PermissionGrant] = [
+            PermissionGrant(
+                group_name=GroupName(DefaultGroup.PUBLIC),
+                permission=PermissionType.READ,
+            ),
+            PermissionGrant(
+                group_name=GroupName(DefaultGroup.PUBLIC),
+                permission=PermissionType.WRITE,
+            ),
+        ]
+
+        # Create collection and run
+        backend.create_collection(
+            name=dag_testkit.dag.name, permissions=default_permissions
+        )
+        dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
 
     # Create linked sources
     linked = linked_sources_factory(
@@ -646,26 +654,34 @@ def create_alt_dedupe_scenario(
     The warehouse contains a single table, indexed in the backend. It has
     been deduplicated twice, by two rival proabilistic models.
     """
-    # First create the admin scenario
-    dag_testkit = create_admin_scenario(
+    # First create the bare scenario
+    dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
     )
 
-    # Set default public permissions
-    default_permissions: list[PermissionGrant] = [
-        PermissionGrant(
-            group_name=GroupName(DefaultGroup.PUBLIC), permission=PermissionType.READ
-        ),
-        PermissionGrant(
-            group_name=GroupName(DefaultGroup.PUBLIC), permission=PermissionType.WRITE
-        ),
-    ]
+    # Server-only: local backends have no users, collections, or runs
+    if isinstance(backend, MatchboxDBAdapter):
+        # First user is admin
+        response = backend.login(User(user_name="alice", email="alice@example.org"))
+        assert response.setup_mode_admin
 
-    # Create collection and run
-    backend.create_collection(
-        name=dag_testkit.dag.name, permissions=default_permissions
-    )
-    dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+        # Set default public permissions
+        default_permissions: list[PermissionGrant] = [
+            PermissionGrant(
+                group_name=GroupName(DefaultGroup.PUBLIC),
+                permission=PermissionType.READ,
+            ),
+            PermissionGrant(
+                group_name=GroupName(DefaultGroup.PUBLIC),
+                permission=PermissionType.WRITE,
+            ),
+        ]
+
+        # Create collection and run
+        backend.create_collection(
+            name=dag_testkit.dag.name, permissions=default_permissions
+        )
+        dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
 
     # Create linked sources
     company_name_feature = FeatureConfig(
@@ -776,26 +792,34 @@ def create_convergent_partial_scenario(
     with repetition, and two naive dedupe models that haven't yet had their
     results inserted.
     """
-    # First create the admin scenario
-    dag_testkit = create_admin_scenario(
+    # First create the bare scenario
+    dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
     )
 
-    # Set default public permissions
-    default_permissions: list[PermissionGrant] = [
-        PermissionGrant(
-            group_name=GroupName(DefaultGroup.PUBLIC), permission=PermissionType.READ
-        ),
-        PermissionGrant(
-            group_name=GroupName(DefaultGroup.PUBLIC), permission=PermissionType.WRITE
-        ),
-    ]
+    # Server-only: local backends have no users, collections, or runs
+    if isinstance(backend, MatchboxDBAdapter):
+        # First user is admin
+        response = backend.login(User(user_name="alice", email="alice@example.org"))
+        assert response.setup_mode_admin
 
-    # Create collection and run
-    backend.create_collection(
-        name=dag_testkit.dag.name, permissions=default_permissions
-    )
-    dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+        # Set default public permissions
+        default_permissions: list[PermissionGrant] = [
+            PermissionGrant(
+                group_name=GroupName(DefaultGroup.PUBLIC),
+                permission=PermissionType.READ,
+            ),
+            PermissionGrant(
+                group_name=GroupName(DefaultGroup.PUBLIC),
+                permission=PermissionType.WRITE,
+            ),
+        ]
+
+        # Create collection and run
+        backend.create_collection(
+            name=dag_testkit.dag.name, permissions=default_permissions
+        )
+        dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
 
     # Create linked sources
     company_name_feature = FeatureConfig(
@@ -925,26 +949,34 @@ def create_mega_scenario(
     Aims to produce "mega" clusters with more features than the CLI has screen rows,
     and more variations than the CLI has screen columns.
     """
-    # First create the admin scenario
-    dag_testkit = create_admin_scenario(
+    # First create the bare scenario
+    dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
     )
 
-    # Set default public permissions
-    default_permissions: list[PermissionGrant] = [
-        PermissionGrant(
-            group_name=GroupName(DefaultGroup.PUBLIC), permission=PermissionType.READ
-        ),
-        PermissionGrant(
-            group_name=GroupName(DefaultGroup.PUBLIC), permission=PermissionType.WRITE
-        ),
-    ]
+    # Server-only: local backends have no users, collections, or runs
+    if isinstance(backend, MatchboxDBAdapter):
+        # First user is admin
+        response = backend.login(User(user_name="alice", email="alice@example.org"))
+        assert response.setup_mode_admin
 
-    # Create collection and run
-    backend.create_collection(
-        name=dag_testkit.dag.name, permissions=default_permissions
-    )
-    dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+        # Set default public permissions
+        default_permissions: list[PermissionGrant] = [
+            PermissionGrant(
+                group_name=GroupName(DefaultGroup.PUBLIC),
+                permission=PermissionType.READ,
+            ),
+            PermissionGrant(
+                group_name=GroupName(DefaultGroup.PUBLIC),
+                permission=PermissionType.WRITE,
+            ),
+        ]
+
+        # Create collection and run
+        backend.create_collection(
+            name=dag_testkit.dag.name, permissions=default_permissions
+        )
+        dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
 
     # ===== FEATURES WITH VARIATIONS (4 string features, 1 variation each) =====
 

--- a/src/matchbox/common/factories/scenarios.py
+++ b/src/matchbox/common/factories/scenarios.py
@@ -1,4 +1,21 @@
-"""Scenario factories for creating TestkitDAG scenarios."""
+"""Scenario factories for creating TestkitDAG scenarios.
+
+A scenario is a builder function registered in SCENARIO_REGISTRY that
+produces a TestkitDAG in a well-defined state, for reuse across tests.
+
+Every scenario's docstring answers two questions.
+
+State: a short, high-level summary of what is set up, such as users, a
+collection or run, and which sources, models, or resolvers exist. Not a
+step-by-step account of the code.
+
+Scope: SERVER or EITHER. SERVER needs a full MatchboxDBAdapter, for
+collections, runs, users, groups, and permissions, guarded by an
+isinstance check that raises TypeError otherwise. EITHER is written only
+against the shared MatchboxClusterStoreAdapter protocol (query, match,
+create_step, insert data). Any server-only setup, such as user permissions
+and runs, is used only when backend is a MatchboxDBAdapter.
+"""
 
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -9,6 +26,10 @@ from polars.testing import assert_frame_equal
 from sqlalchemy import Engine
 
 from matchbox.client.queries import Query
+from matchbox.common.adapters.protocol import (
+    MatchboxClusterStoreAdapter,
+    MatchboxSnapshot,
+)
 from matchbox.common.dtos import (
     DefaultGroup,
     Group,
@@ -30,7 +51,7 @@ from matchbox.common.factories.sources import (
     SourceTestkitParameters,
     linked_sources_factory,
 )
-from matchbox.server.base import MatchboxDBAdapter, MatchboxSnapshot
+from matchbox.server.base import MatchboxDBAdapter
 
 # Type definitions
 ScenarioBuilder = Callable[..., TestkitDAG]
@@ -79,12 +100,40 @@ def _testkitdag_to_location(client: Engine, dag: TestkitDAG) -> None:
         source_testkit.write_to_location(set_client=client)
 
 
+def _setup_basic_server(backend: MatchboxDBAdapter, dag_testkit: TestkitDAG) -> None:
+    """Basic server-only setup shared by EITHER scenarios.
+
+    Logs in an admin user, alice, grants the public group default read
+    and write permissions, then creates a collection and run named after
+    the DAG. Local backends have no concept of users, collections, or
+    runs, so callers only use this when backend is a MatchboxDBAdapter.
+    """
+    response = backend.login(User(user_name="alice", email="alice@example.org"))
+    assert response.setup_mode_admin
+
+    default_permissions: list[PermissionGrant] = [
+        PermissionGrant(
+            group_name=GroupName(DefaultGroup.PUBLIC),
+            permission=PermissionType.READ,
+        ),
+        PermissionGrant(
+            group_name=GroupName(DefaultGroup.PUBLIC),
+            permission=PermissionType.WRITE,
+        ),
+    ]
+
+    backend.create_collection(
+        name=dag_testkit.dag.name, permissions=default_permissions
+    )
+    dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+
+
 # Scenario builders
 
 
 @register_scenario("bare")
 def create_bare_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -92,7 +141,9 @@ def create_bare_scenario(
 ) -> TestkitDAG:
     """Create a bare TestkitDAG scenario.
 
-    The warehouse and backend are empty, no users.
+    State: the warehouse and backend are empty, with no users.
+
+    Scope: EITHER, since it touches nothing on backend.
     """
     return TestkitDAG()
 
@@ -107,8 +158,18 @@ def create_admin_scenario(
 ) -> TestkitDAG:
     """Create an admin TestkitDAG scenario.
 
-    The warehouse and backend are empty except for a single admin user, alice.
+    State: the warehouse and backend are empty except for a single admin
+    user, alice.
+
+    Scope: SERVER only, since it creates a login and admin user, a
+    concept local backends do not have. Raises TypeError if given
+    anything but a MatchboxDBAdapter.
     """
+    if not isinstance(backend, MatchboxDBAdapter):
+        raise TypeError(
+            f"The 'admin' scenario is server-only, not {type(backend).__name__}."
+        )
+
     # First create the bare scenario
     dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
@@ -131,16 +192,21 @@ def create_closed_collection_scenario(
 ) -> TestkitDAG:
     """Create a closed collection scenario for permission testing.
 
-    Users:
-    - alice: admin (from setup_mode_admin)
-    - bob: member of 'readers' group (has READ)
-    - charlie: member of 'writers' group (has READ + WRITE)
-    - dave: no permissions (public group only)
+    State:
 
-    Collection 'restricted' has:
-    - READ permission granted to 'readers' group
-    - WRITE permission granted to 'writers' group
-    - No public permissions
+    - Users
+        - alice: admin (from setup_mode_admin)
+        - bob: member of 'readers' group (has READ)
+        - charlie: member of 'writers' group (has READ + WRITE)
+        - dave: no permissions (public group only)
+    - Collection 'restricted' has:
+        - READ permission granted to 'readers' group
+        - WRITE permission granted to 'writers' group
+        - No public permissions
+
+    Scope: SERVER only. Inherits the guard from create_admin_scenario,
+    called first, then uses groups and permissions, concepts local
+    backends also lack.
     """
     # Start with admin scenario
     dag_testkit = create_admin_scenario(
@@ -186,7 +252,7 @@ def create_closed_collection_scenario(
 
 @register_scenario("preindex")
 def create_preindex_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -194,39 +260,19 @@ def create_preindex_scenario(
 ) -> TestkitDAG:
     """Create a preindex TestkitDAG scenario.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. The warehouse holds three
+    linked, unindexed source tables, crn, dh, and cdms, covering common
+    realistic linkage cases.
 
-    The warehouse contains three interlinked tables that cover common linkage
-    realistic scenarios, but are not yet indexed.
+    Scope: EITHER
     """
     # First create the bare scenario
     dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
     )
 
-    # Server-only: local backends have no users, collections, or runs
     if isinstance(backend, MatchboxDBAdapter):
-        # First user is admin
-        response = backend.login(User(user_name="alice", email="alice@example.org"))
-        assert response.setup_mode_admin
-
-        # Set default public permissions
-        default_permissions: list[PermissionGrant] = [
-            PermissionGrant(
-                group_name=GroupName(DefaultGroup.PUBLIC),
-                permission=PermissionType.READ,
-            ),
-            PermissionGrant(
-                group_name=GroupName(DefaultGroup.PUBLIC),
-                permission=PermissionType.WRITE,
-            ),
-        ]
-
-        # Create collection and run
-        backend.create_collection(
-            name=dag_testkit.dag.name, permissions=default_permissions
-        )
-        dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+        _setup_basic_server(backend, dag_testkit)
 
     # Create linked sources
     linked = linked_sources_factory(
@@ -245,7 +291,7 @@ def create_preindex_scenario(
 
 @register_scenario("index")
 def create_index_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -253,10 +299,10 @@ def create_index_scenario(
 ) -> TestkitDAG:
     """Create an index TestkitDAG scenario.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. The warehouse's three
+    linked source tables, crn, dh, and cdms, are indexed in the backend.
 
-    The warehouse contains three interlinked tables that cover common linkage
-    realistic scenarios. They are indexed in the backend.
+    Scope: EITHER
     """
     # First create the preindex scenario
     dag_testkit = create_preindex_scenario(
@@ -279,7 +325,7 @@ def create_index_scenario(
 
 @register_scenario("dedupe")
 def create_dedupe_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -287,10 +333,11 @@ def create_dedupe_scenario(
 ) -> TestkitDAG:
     """Create a dedupe TestkitDAG scenario.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. The warehouse's three
+    linked source tables are indexed, and each is deduplicated by its own
+    naive model and resolver.
 
-    The warehouse contains three interlinked tables that cover common linkage
-    realistic scenarios. They are indexed and deduplicated in the backend.
+    Scope: EITHER
     """
     # First create the index scenario
     dag_testkit = create_index_scenario(
@@ -350,7 +397,7 @@ def create_dedupe_scenario(
 
 @register_scenario("scored_dedupe")
 def create_scored_dedupe_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -358,11 +405,11 @@ def create_scored_dedupe_scenario(
 ) -> TestkitDAG:
     """Create a scored dedupe TestkitDAG scenario.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. The warehouse's three
+    linked source tables are indexed and deduplicated using scored, not
+    deterministic, methodologies, each resolved at a 0.5 threshold.
 
-    The warehouse contains three interlinked tables that cover common linkage
-    realistic scenarios. They are indexed and deduplicated in the backend using
-    scored methodologies.
+    Scope: EITHER
     """
     # First create the index scenario
     dag_testkit = create_index_scenario(
@@ -423,7 +470,7 @@ def create_scored_dedupe_scenario(
 
 @register_scenario("link")
 def create_link_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -431,10 +478,11 @@ def create_link_scenario(
 ) -> TestkitDAG:
     """Create a link TestkitDAG scenario.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. Builds on dedupe. Crn and
+    dh are linked, as are crn and cdms, then everything is joined into a
+    single final_join resolver.
 
-    The warehouse contains three interlinked tables that cover common linkage
-    realistic scenarios. They are indexed, deduplicated and linked in the backend.
+    Scope: EITHER
     """
     # First create the dedupe scenario
     dag_testkit = create_dedupe_scenario(
@@ -641,7 +689,7 @@ def create_link_scenario(
 
 @register_scenario("alt_dedupe")
 def create_alt_dedupe_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -649,39 +697,19 @@ def create_alt_dedupe_scenario(
 ) -> TestkitDAG:
     """Create a TestkitDAG scenario with two alternative dedupers.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. The warehouse has a single
+    table, foo_a, indexed and deduplicated twice by two rival
+    probabilistic models at different thresholds, 0.5 and 0.75.
 
-    The warehouse contains a single table, indexed in the backend. It has
-    been deduplicated twice, by two rival proabilistic models.
+    Scope: EITHER
     """
     # First create the bare scenario
     dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
     )
 
-    # Server-only: local backends have no users, collections, or runs
     if isinstance(backend, MatchboxDBAdapter):
-        # First user is admin
-        response = backend.login(User(user_name="alice", email="alice@example.org"))
-        assert response.setup_mode_admin
-
-        # Set default public permissions
-        default_permissions: list[PermissionGrant] = [
-            PermissionGrant(
-                group_name=GroupName(DefaultGroup.PUBLIC),
-                permission=PermissionType.READ,
-            ),
-            PermissionGrant(
-                group_name=GroupName(DefaultGroup.PUBLIC),
-                permission=PermissionType.WRITE,
-            ),
-        ]
-
-        # Create collection and run
-        backend.create_collection(
-            name=dag_testkit.dag.name, permissions=default_permissions
-        )
-        dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+        _setup_basic_server(backend, dag_testkit)
 
     # Create linked sources
     company_name_feature = FeatureConfig(
@@ -778,7 +806,7 @@ def create_alt_dedupe_scenario(
 
 @register_scenario("convergent_partial")
 def create_convergent_partial_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -786,40 +814,19 @@ def create_convergent_partial_scenario(
 ) -> TestkitDAG:
     """Create a TestkitDAG scenario with convergent sources.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. Two sources, foo_a and
+    foo_b, index almost identically, each with repetition, and each has
+    a naive dedupe model built but not yet inserted.
 
-    Two sources index almost identically. TestkitDAG contains two indexed sources
-    with repetition, and two naive dedupe models that haven't yet had their
-    results inserted.
+    Scope: EITHER
     """
     # First create the bare scenario
     dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
     )
 
-    # Server-only: local backends have no users, collections, or runs
     if isinstance(backend, MatchboxDBAdapter):
-        # First user is admin
-        response = backend.login(User(user_name="alice", email="alice@example.org"))
-        assert response.setup_mode_admin
-
-        # Set default public permissions
-        default_permissions: list[PermissionGrant] = [
-            PermissionGrant(
-                group_name=GroupName(DefaultGroup.PUBLIC),
-                permission=PermissionType.READ,
-            ),
-            PermissionGrant(
-                group_name=GroupName(DefaultGroup.PUBLIC),
-                permission=PermissionType.WRITE,
-            ),
-        ]
-
-        # Create collection and run
-        backend.create_collection(
-            name=dag_testkit.dag.name, permissions=default_permissions
-        )
-        dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+        _setup_basic_server(backend, dag_testkit)
 
     # Create linked sources
     company_name_feature = FeatureConfig(
@@ -882,7 +889,7 @@ def create_convergent_partial_scenario(
 
 @register_scenario("convergent")
 def create_convergent_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -890,10 +897,11 @@ def create_convergent_scenario(
 ) -> TestkitDAG:
     """Create a TestkitDAG scenario with convergent sources, deduped.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. Builds on
+    convergent_partial. Both near-identical sources have their dedupe
+    models and resolvers inserted into the backend.
 
-    This is where two sources index almost identically. TestkitDAG contains two
-    indexed sources with repetition, and two naive dedupe models, all inserted.
+    Scope: EITHER
     """
     dag_testkit = create_convergent_partial_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
@@ -933,7 +941,7 @@ def create_convergent_scenario(
 
 @register_scenario("mega")
 def create_mega_scenario(
-    backend: MatchboxDBAdapter,
+    backend: MatchboxClusterStoreAdapter,
     warehouse_engine: Engine,
     n_entities: int = 10,
     seed: int = 42,
@@ -941,42 +949,20 @@ def create_mega_scenario(
 ) -> TestkitDAG:
     """Create a TestkitDAG scenario that produces large clusters.
 
-    One admin user, alice.
+    State: one admin user, alice, server only. Two tables with many
+    features, marketplace_a and marketplace_b, are indexed and linked,
+    producing mega clusters with more features than the CLI has screen
+    rows, and more variations than it has screen columns.
 
-    Two tables with many features are in the warehouse. They are indexed and linked
-    in the backend.
-
-    Aims to produce "mega" clusters with more features than the CLI has screen rows,
-    and more variations than the CLI has screen columns.
+    Scope: EITHER
     """
     # First create the bare scenario
     dag_testkit = create_bare_scenario(
         backend, warehouse_engine, n_entities, seed, **kwargs
     )
 
-    # Server-only: local backends have no users, collections, or runs
     if isinstance(backend, MatchboxDBAdapter):
-        # First user is admin
-        response = backend.login(User(user_name="alice", email="alice@example.org"))
-        assert response.setup_mode_admin
-
-        # Set default public permissions
-        default_permissions: list[PermissionGrant] = [
-            PermissionGrant(
-                group_name=GroupName(DefaultGroup.PUBLIC),
-                permission=PermissionType.READ,
-            ),
-            PermissionGrant(
-                group_name=GroupName(DefaultGroup.PUBLIC),
-                permission=PermissionType.WRITE,
-            ),
-        ]
-
-        # Create collection and run
-        backend.create_collection(
-            name=dag_testkit.dag.name, permissions=default_permissions
-        )
-        dag_testkit.dag.run = backend.create_run(collection=dag_testkit.dag.name).run_id
+        _setup_basic_server(backend, dag_testkit)
 
     # ===== FEATURES WITH VARIATIONS (4 string features, 1 variation each) =====
 

--- a/src/matchbox/common/factories/scenarios.py
+++ b/src/matchbox/common/factories/scenarios.py
@@ -101,7 +101,7 @@ def _testkitdag_to_location(client: Engine, dag: TestkitDAG) -> None:
 
 
 def _setup_basic_server(backend: MatchboxDBAdapter, dag_testkit: TestkitDAG) -> None:
-    """Basic server-only setup shared by EITHER scenarios.
+    """Basic server-only setup.
 
     Logs in an admin user, alice, grants the public group default read
     and write permissions, then creates a collection and run named after

--- a/src/matchbox/server/base.py
+++ b/src/matchbox/server/base.py
@@ -1,8 +1,6 @@
 """Base classes and utilities for Matchbox database adapters."""
 
-import json
 from abc import ABC, abstractmethod
-from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, Self
 
 import boto3
@@ -10,7 +8,6 @@ from botocore.exceptions import ClientError
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from pyarrow import Table
 from pydantic import (
-    BaseModel,
     Field,
     SecretBytes,
     SecretStr,
@@ -22,6 +19,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from matchbox.common.adapters.protocol import (
     Countable,
     ListableAndCountable,
+    MatchboxBackends,
     MatchboxClusterStoreAdapter,
 )
 from matchbox.common.dtos import (
@@ -104,29 +102,6 @@ A list of tuples in the form:
 * The resource type to grant it on
 * The resource name to grant it on, if applicable
 """
-
-
-class MatchboxBackends(StrEnum):
-    """The available backends for Matchbox."""
-
-    POSTGRES = "postgres"
-
-
-class MatchboxSnapshot(BaseModel):
-    """A snapshot of the Matchbox database."""
-
-    backend_type: MatchboxBackends
-    data: dict[str, Any]
-
-    @field_validator("data")
-    @classmethod
-    def check_serialisable(cls, value: dict[str, Any]) -> dict[str, Any]:
-        """Validate that the value can be serialised to JSON."""
-        try:
-            json.dumps(value)
-            return value
-        except (TypeError, OverflowError) as e:
-            raise ValueError(f"Value is not JSON serialisable: {e}") from e
 
 
 class MatchboxDatastoreSettings(BaseSettings):
@@ -525,47 +500,6 @@ class MatchboxDBAdapter(MatchboxClusterStoreAdapter, ABC):
 
         Raises:
             MatchboxDataNotFound: If some items don't exist in the target table.
-        """
-        ...
-
-    @abstractmethod
-    def dump(self) -> MatchboxSnapshot:
-        """Dumps the entire database to a snapshot.
-
-        Returns:
-            A MatchboxSnapshot object of type "postgres" with the database's
-                current state.
-        """
-        ...
-
-    @abstractmethod
-    def drop(self, certain: bool) -> None:
-        """Hard clear the database by dropping all tables and re-creating.
-
-        Args:
-            certain: Whether to drop the database without confirmation.
-        """
-        ...
-
-    @abstractmethod
-    def clear(self, certain: bool) -> None:
-        """Soft clear the database by deleting all rows but retaining tables.
-
-        Args:
-            certain: Whether to delete the database without confirmation.
-        """
-        ...
-
-    @abstractmethod
-    def restore(self, snapshot: MatchboxSnapshot) -> None:
-        """Restores the database from a snapshot.
-
-        Args:
-            snapshot: A MatchboxSnapshot object of type "postgres" with the
-                database's state
-
-        Raises:
-            TypeError: If the snapshot is not compatible with PostgreSQL
         """
         ...
 

--- a/src/matchbox/server/base.py
+++ b/src/matchbox/server/base.py
@@ -3,7 +3,7 @@
 import json
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, Protocol, Self
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 import boto3
 from botocore.exceptions import ClientError
@@ -19,6 +19,11 @@ from pydantic import (
 )
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from matchbox.common.adapters.protocol import (
+    Countable,
+    ListableAndCountable,
+    MatchboxClusterStoreAdapter,
+)
 from matchbox.common.dtos import (
     BackendResourceType,
     Collection,
@@ -28,14 +33,11 @@ from matchbox.common.dtos import (
     Group,
     GroupName,
     LoginResponse,
-    Match,
-    ModelStepPath,
     PermissionGrant,
     PermissionType,
     ResolverStepPath,
     Run,
     RunID,
-    SourceStepPath,
     Step,
     StepPath,
     UploadStage,
@@ -304,33 +306,15 @@ def initialise_matchbox() -> None:
     BackendManager.initialise(settings)
 
 
-class Countable(Protocol):
-    """A protocol for objects that can be counted."""
-
-    def count(self) -> int:
-        """Counts the number of items in the object."""
-        ...
-
-
-class Listable(Protocol):
-    """A protocol for objects that can be listed."""
-
-    def list_all(self) -> list[str]:
-        """Lists the items in the object."""
-        ...
-
-
-class ListableAndCountable(Countable, Listable):
-    """A protocol for objects that can be counted and listed."""
-
-    pass
-
-
-class MatchboxDBAdapter(ABC):
+class MatchboxDBAdapter(MatchboxClusterStoreAdapter, ABC):
     """An abstract base class for Matchbox database adapters.
 
     By default the database should contain the users, groups and permissions found in
     DEFAULT_GROUPS and DEFAULT_PERMISSIONS.
+
+    Extends MatchboxClusterStoreAdapter (the query block, data block, and
+    cluster counts) with the server-only surface: collections, runs, step
+    metadata management, upload staging, admin, groups, and evaluation.
     """
 
     settings: "MatchboxServerSettings"
@@ -338,56 +322,8 @@ class MatchboxDBAdapter(ABC):
     sources: ListableAndCountable
     models: Countable
     resolvers: Countable
-    source_clusters: Countable
-    model_clusters: Countable
-    all_clusters: Countable
-    creates: Countable
-    merges: Countable
-    proposes: Countable
     source_steps: Countable
     users: Countable
-
-    # Retrieval
-
-    @abstractmethod
-    def query(
-        self,
-        source: SourceStepPath,
-        resolver: ResolverStepPath | None = None,
-        return_leaf_id: bool = False,
-        limit: int | None = None,
-    ) -> Table:
-        """Queries the database from an optional resolution.
-
-        Args:
-            source: The step path identifying the source to query.
-            resolver (optional): The resolver path to use for filtering results.
-                If not specified, the source step is used for the queried source.
-            return_leaf_id (optional): whether to return cluster ID of leaves
-            limit (optional): the number to use in a limit clause. Useful for testing
-
-        Returns:
-            The resulting matchbox IDs in Arrow format
-        """
-        ...
-
-    @abstractmethod
-    def match(
-        self,
-        key: str,
-        source: SourceStepPath,
-        targets: list[SourceStepPath],
-        resolver: ResolverStepPath,
-    ) -> list[Match]:
-        """Match an ID in a source step and return the keys in the targets.
-
-        Args:
-            key: The key to match from the source.
-            source: The path of the source step.
-            targets: The paths of the target source steps.
-            resolver: The resolver path to use for matching.
-        """
-        ...
 
     # Collection management
 
@@ -511,16 +447,6 @@ class MatchboxDBAdapter(ABC):
     # Step management
 
     @abstractmethod
-    def create_step(self, step: Step, path: StepPath) -> None:
-        """Write a step to Matchbox.
-
-        Args:
-            step: Step object with a source, model, or resolver config
-            path: The step path
-        """
-        ...
-
-    @abstractmethod
     def get_step(self, path: StepPath) -> Step:
         """Get a step from its path.
 
@@ -586,43 +512,6 @@ class MatchboxDBAdapter(ABC):
         Args:
             path: The path of the step to target.
         """
-        ...
-
-    @abstractmethod
-    def insert_source_data(self, path: SourceStepPath, data_hashes: Table) -> None:
-        """Insert hash data for a source step.
-
-        Only possible if data fingerprint matches fingerprint declared when the
-        step was created. Data can only be set once on a step.
-
-        Args:
-            path: The path of the source step to index.
-            data_hashes: The Arrow table with the hash of each data row
-        """
-        ...
-
-    @abstractmethod
-    def insert_model_data(self, path: ModelStepPath, results: Table) -> None:
-        """Insert results data for a model step.
-
-        Only possible if data fingerprint matches fingerprint declared when the
-        step was created. Data can only be set once on a step.
-        """
-        ...
-
-    @abstractmethod
-    def insert_resolver_data(self, path: ResolverStepPath, data: Table) -> None:
-        """Insert resolver cluster assignments for a resolver step."""
-        ...
-
-    @abstractmethod
-    def get_model_data(self, path: ModelStepPath) -> Table:
-        """Get the results for a model step."""
-        ...
-
-    @abstractmethod
-    def get_resolver_data(self, path: ResolverStepPath) -> Table:
-        """Get cluster assignments for a resolver step."""
         ...
 
     # Data management

--- a/src/matchbox/server/postgresql/adapter/admin.py
+++ b/src/matchbox/server/postgresql/adapter/admin.py
@@ -335,7 +335,7 @@ class MatchboxPostgresAdminMixin:
         if missing_ids:
             raise MatchboxDataNotFound(
                 message="Some items don't exist in Clusters table.",
-                table=Clusters.__tablename__,
+                table=Clusters.__table__.name,
                 data=list(missing_ids),
             )
 

--- a/src/matchbox/server/postgresql/adapter/admin.py
+++ b/src/matchbox/server/postgresql/adapter/admin.py
@@ -4,6 +4,7 @@ from typing import Literal, cast
 
 from sqlalchemy import CursorResult, and_, bindparam, delete, select, union_all
 
+from matchbox.common.adapters.protocol import MatchboxSnapshot
 from matchbox.common.dtos import (
     BackendResourceType,
     CollectionName,
@@ -22,10 +23,7 @@ from matchbox.common.exceptions import (
     MatchboxGroupNotFoundError,
 )
 from matchbox.common.logging import logger
-from matchbox.server.base import (
-    PERMISSION_GRANTS,
-    MatchboxSnapshot,
-)
+from matchbox.server.base import PERMISSION_GRANTS
 from matchbox.server.postgresql.db import (
     MBDB,
     MatchboxBackends,

--- a/src/matchbox/server/postgresql/adapter/collections.py
+++ b/src/matchbox/server/postgresql/adapter/collections.py
@@ -4,6 +4,7 @@ from psycopg.errors import LockNotAvailable
 from pyarrow import Table
 from sqlalchemy import CursorResult, delete, select, update
 
+from matchbox.common.adapters.sql.query import resolver_membership_subquery
 from matchbox.common.arrow import SCHEMA_CLUSTERS, SCHEMA_MODEL_EDGES
 from matchbox.common.db import sql_to_df
 from matchbox.common.dtos import (
@@ -51,7 +52,6 @@ from matchbox.server.postgresql.utils.insert import (
 )
 from matchbox.server.postgresql.utils.query import (
     require_complete_resolver,
-    resolver_membership_subquery,
 )
 
 

--- a/src/matchbox/server/postgresql/adapter/main.py
+++ b/src/matchbox/server/postgresql/adapter/main.py
@@ -128,8 +128,8 @@ class MatchboxPostgres(
         self.source_clusters = FilteredClusters(has_source=True)
         self.model_clusters = FilteredClusters(has_source=False)
         self.all_clusters = FilteredClusters()
-        self.creates = ResolverClusters
-        self.merges = Contains
-        self.proposes = FilteredProbabilities()
+        self.creates = ResolverClusters  # clusters proposed by resolver
+        self.merges = Contains  # cluster lineage tree
+        self.proposes = FilteredProbabilities()  # raw model edge scores
         self.source_steps = FilteredSteps(sources=True, models=False, resolvers=False)
         self.users = Users

--- a/src/matchbox/server/postgresql/alembic/env.py
+++ b/src/matchbox/server/postgresql/alembic/env.py
@@ -21,7 +21,9 @@ def run_migrations_online() -> None:
         config_section,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
-    )
+    ).execution_options(
+        schema_translate_map={"mb": MBDB.settings.postgres.db_schema}
+    )  # schema="mb" is a symbolic token
 
     def _include_name(name: str, type_: str, _: dict[str, str]) -> bool:
         """Ensure only Matchbox's schema is used to generate diffs."""

--- a/src/matchbox/server/postgresql/db.py
+++ b/src/matchbox/server/postgresql/db.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.pool import QueuePool
 
-from matchbox.common.adapters.sql.tables import metadata as shared_metadata
+from matchbox.common.adapters.sql.tables import METADATA
 from matchbox.common.datatypes import require
 from matchbox.common.logging import logger
 from matchbox.server.base import MatchboxBackends, MatchboxServerSettings
@@ -82,7 +82,7 @@ class MatchboxDatabase:
         self._adbc_pool: QueuePool | None = None
         self._adbc_lock = threading.Lock()
         self._source_adbc_connection: adbc_dbapi.Connection | None = None
-        self.MatchboxBase = declarative_base(metadata=shared_metadata)
+        self.MatchboxBase = declarative_base(metadata=METADATA)
         self.alembic_config = settings.postgres.get_alembic_config()
 
     def connection_string(self, driver: bool = True) -> str:

--- a/src/matchbox/server/postgresql/db.py
+++ b/src/matchbox/server/postgresql/db.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from matchbox.common.adapters.sql.tables import metadata as shared_metadata
 from matchbox.common.datatypes import require
 from matchbox.common.logging import logger
 from matchbox.server.base import MatchboxBackends, MatchboxServerSettings
@@ -81,9 +82,7 @@ class MatchboxDatabase:
         self._adbc_pool: QueuePool | None = None
         self._adbc_lock = threading.Lock()
         self._source_adbc_connection: adbc_dbapi.Connection | None = None
-        self.MatchboxBase = declarative_base(
-            metadata=MetaData(schema=settings.postgres.db_schema)
-        )
+        self.MatchboxBase = declarative_base(metadata=shared_metadata)
         self.alembic_config = settings.postgres.get_alembic_config()
 
     def connection_string(self, driver: bool = True) -> str:
@@ -101,7 +100,9 @@ class MatchboxDatabase:
         """Connect to the database."""
         self._engine = create_engine(
             url=self.connection_string(), logging_name="matchbox.engine", echo=False
-        )
+        ).execution_options(
+            schema_translate_map={"mb": self.settings.postgres.db_schema}
+        )  # schema="mb" is a symbolic token
         self._SessionLocal = sessionmaker(
             autocommit=False, autoflush=False, bind=self._engine
         )
@@ -205,7 +206,7 @@ class MatchboxDatabase:
         - TRUNCATE tables that are part of the core ORM (preserves structure)
         - DROP tables that are not in the ORM (removes temporary/test tables)
         """
-        schema_name = self.MatchboxBase.metadata.schema
+        schema_name = self.settings.postgres.db_schema
         engine = self.get_engine()  # Get the engine
 
         with self.get_session() as session:

--- a/src/matchbox/server/postgresql/orm.py
+++ b/src/matchbox/server/postgresql/orm.py
@@ -7,7 +7,6 @@ from sqlalchemy import (
     BIGINT,
     BOOLEAN,
     INTEGER,
-    REAL,
     CheckConstraint,
     DateTime,
     Enum,
@@ -21,6 +20,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import BYTEA, JSONB, TEXT, insert
 from sqlalchemy.orm import Mapped, Session, mapped_column, relationship, selectinload
 
+from matchbox.common.adapters.sql import tables
 from matchbox.common.dtos import (
     BackendResourceType,
     CollectionName,
@@ -670,31 +670,11 @@ class SourceFields(CountMixin, MBDB.MatchboxBase):
 class ClusterSourceKey(CountMixin, MBDB.MatchboxBase):
     """Table for storing source primary keys for clusters."""
 
-    __tablename__ = "cluster_keys"
-
-    # Columns
-    key_id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
-    cluster_id: Mapped[int] = mapped_column(
-        BIGINT, ForeignKey("clusters.cluster_id", ondelete="CASCADE"), nullable=False
-    )
-    source_config_id: Mapped[int] = mapped_column(
-        BIGINT,
-        ForeignKey("source_configs.source_config_id", ondelete="CASCADE"),
-        nullable=False,
-    )
-    key: Mapped[str] = mapped_column(TEXT, nullable=False)
+    __table__ = tables.ClusterSourceKey
 
     # Relationships
     cluster: Mapped["Clusters"] = relationship(back_populates="keys")
     source_config: Mapped["SourceConfigs"] = relationship(back_populates="cluster_keys")
-
-    # Constraints and indices
-    __table_args__ = (
-        Index("ix_cluster_keys_cluster_id", "cluster_id"),
-        Index("ix_cluster_keys_keys", "key"),
-        Index("ix_cluster_keys_source_config_id", "source_config_id"),
-        UniqueConstraint("key_id", "source_config_id", name="unique_keys_source"),
-    )
 
 
 class SourceConfigs(CountMixin, MBDB.MatchboxBase):
@@ -936,33 +916,13 @@ class ResolverConfigs(CountMixin, MBDB.MatchboxBase):
 class Contains(CountMixin, MBDB.MatchboxBase):
     """Cluster lineage table."""
 
-    __tablename__ = "contains"
-
-    # Columns
-    root: Mapped[int] = mapped_column(
-        BIGINT, ForeignKey("clusters.cluster_id", ondelete="CASCADE"), primary_key=True
-    )
-    leaf: Mapped[int] = mapped_column(
-        BIGINT, ForeignKey("clusters.cluster_id", ondelete="CASCADE"), primary_key=True
-    )
-
-    # Constraints and indices
-    __table_args__ = (
-        CheckConstraint("root != leaf", name="no_self_containment"),
-        UniqueConstraint("root", "leaf"),
-        Index("ix_contains_root_leaf", "root", "leaf"),
-        Index("ix_contains_leaf_root", "leaf", "root"),
-    )
+    __table__ = tables.Contains
 
 
 class Clusters(CountMixin, MBDB.MatchboxBase):
     """Table of indexed data and clusters that match it."""
 
-    __tablename__ = "clusters"
-
-    # Columns
-    cluster_id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
-    cluster_hash: Mapped[bytes] = mapped_column(BYTEA, nullable=False)
+    __table__ = tables.Clusters
 
     # Relationships
     keys: Mapped[list["ClusterSourceKey"]] = relationship(
@@ -984,9 +944,6 @@ class Clusters(CountMixin, MBDB.MatchboxBase):
         ),
         viewonly=True,
     )
-
-    # Constraints and indices
-    __table_args__ = (UniqueConstraint("cluster_hash", name="clusters_hash_key"),)
 
 
 class UserGroups(MBDB.MatchboxBase):
@@ -1212,51 +1169,15 @@ class ModelEdges(CountMixin, MBDB.MatchboxBase):
     Stores the raw left/right scores created by a model.
     """
 
-    __tablename__ = "model_edges"
-
-    # Columns
-    result_id: Mapped[int] = mapped_column(BIGINT, primary_key=True, autoincrement=True)
-    step_id: Mapped[int] = mapped_column(
-        BIGINT,
-        ForeignKey("steps.step_id", ondelete="CASCADE"),
-        nullable=False,
-    )
-    left_id: Mapped[int] = mapped_column(
-        BIGINT, ForeignKey("clusters.cluster_id", ondelete="CASCADE"), nullable=False
-    )
-    right_id: Mapped[int] = mapped_column(
-        BIGINT, ForeignKey("clusters.cluster_id", ondelete="CASCADE"), nullable=False
-    )
-    score: Mapped[float] = mapped_column(REAL, nullable=False)
+    __table__ = tables.ModelEdges
 
     # Relationships
     proposed_by: Mapped["Steps"] = relationship(back_populates="model_edges")
-
-    # Constraints
-    __table_args__ = (
-        Index("ix_model_edges_step", "step_id"),
-        CheckConstraint(
-            "score >= 0.0 AND score <= 1.0",
-            name="valid_score",
-        ),
-        UniqueConstraint("step_id", "left_id", "right_id"),
-    )
 
 
 class ResolverClusters(CountMixin, MBDB.MatchboxBase):
     """Association table linking resolver steps to cluster IDs."""
 
-    __tablename__ = "resolver_clusters"
-
-    step_id: Mapped[int] = mapped_column(
-        BIGINT,
-        ForeignKey("steps.step_id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-    cluster_id: Mapped[int] = mapped_column(
-        BIGINT, ForeignKey("clusters.cluster_id", ondelete="CASCADE"), primary_key=True
-    )
+    __table__ = tables.ResolverClusters
 
     proposed_by: Mapped["Steps"] = relationship(back_populates="resolver_clusters")
-
-    __table_args__ = (Index("ix_resolver_clusters_step", "step_id"),)

--- a/src/matchbox/server/postgresql/utils/db.py
+++ b/src/matchbox/server/postgresql/utils/db.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import Select
 from sqlalchemy.sql.type_api import TypeEngine
 
+from matchbox.common.adapters.protocol import MatchboxBackends, MatchboxSnapshot
 from matchbox.common.datatypes import require
 from matchbox.common.dtos import (
     BackendResourceType,
@@ -30,7 +31,6 @@ from matchbox.common.exceptions import (
     MatchboxGroupNotFoundError,
 )
 from matchbox.common.logging import logger
-from matchbox.server.base import MatchboxBackends, MatchboxSnapshot
 from matchbox.server.postgresql.db import MBDB
 from matchbox.server.postgresql.orm import Collections, Groups, Permissions
 

--- a/src/matchbox/server/postgresql/utils/insert.py
+++ b/src/matchbox/server/postgresql/utils/insert.py
@@ -12,8 +12,12 @@ from sqlalchemy.dialects.postgresql import (
 )
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import TableClause
-from sqlalchemy.sql.selectable import Subquery
 
+from matchbox.common.adapters.sql.resolver import (
+    build_expanded_leaves_subquery,
+    build_leaf_hash_groups_query,
+    hash_resolver_parents,
+)
 from matchbox.common.dtos import (
     ModelStepPath,
     ResolverStepPath,
@@ -26,7 +30,6 @@ from matchbox.common.exceptions import (
 )
 from matchbox.common.hash import hash_arrow_table, hash_clusters, hash_model_results
 from matchbox.common.logging import logger
-from matchbox.common.transform import hash_cluster_leaves
 from matchbox.server.postgresql.db import MBDB
 from matchbox.server.postgresql.orm import (
     Clusters,
@@ -250,30 +253,6 @@ def insert_model_edges(
     logger.info("Model edge insert complete!", prefix=log_prefix)
 
 
-def _build_expanded_leaves_subquery(
-    incoming_cluster_assignments: TableClause,
-) -> Subquery:
-    """Expand child assignments to leaf-level cluster IDs per parent cluster."""
-    return (
-        select(
-            incoming_cluster_assignments.c.parent_id,
-            func.coalesce(
-                Contains.leaf,
-                incoming_cluster_assignments.c.child_id,
-            ).label("leaf_id"),
-        )
-        .distinct()
-        .select_from(
-            # Clusters with no children in Contains resolve to themselves
-            incoming_cluster_assignments.outerjoin(
-                Contains,
-                Contains.root == incoming_cluster_assignments.c.child_id,
-            )
-        )
-        .subquery("expanded_leaves")
-    )
-
-
 def _compute_resolver_hashes(
     incoming_cluster_assignments: TableClause,
     session: Session,
@@ -302,32 +281,11 @@ def _compute_resolver_hashes(
         Arrow table with columns (parent_id: int64, cluster_hash: binary).
     """
     # Expand each child_id to its constituent leaves
-    expanded_leaves = _build_expanded_leaves_subquery(incoming_cluster_assignments)
+    expanded_leaves = build_expanded_leaves_subquery(incoming_cluster_assignments)
 
-    # Group leaf hashes per parent_id
-    rows = session.execute(
-        select(
-            expanded_leaves.c.parent_id,
-            func.array_agg(Clusters.cluster_hash).label("leaf_hashes"),
-        )
-        .select_from(
-            expanded_leaves.join(
-                Clusters,
-                Clusters.cluster_id == expanded_leaves.c.leaf_id,
-            )
-        )
-        .group_by(expanded_leaves.c.parent_id)
-    ).all()
-
-    # Compute a single composite hash per parent cluster from leaf hashes
-    return pa.table(
-        {
-            "parent_id": [int(r[0]) for r in rows],
-            "cluster_hash": [
-                hash_cluster_leaves([bytes(h) for h in r[1]]) for r in rows
-            ],
-        }
-    )
+    # Group leaf hashes per parent_id, then hash them into a composite hash
+    rows = session.execute(build_leaf_hash_groups_query(expanded_leaves)).all()
+    return hash_resolver_parents(rows)
 
 
 def insert_clusters(
@@ -407,7 +365,7 @@ def insert_clusters(
         hash_data = _compute_resolver_hashes(incoming_cluster_assignments, session)
 
         # Leaf expansion subquery
-        expanded_leaves = _build_expanded_leaves_subquery(incoming_cluster_assignments)
+        expanded_leaves = build_expanded_leaves_subquery(incoming_cluster_assignments)
 
         # 3) Insert everything
         with ingest_to_temporary_table(

--- a/src/matchbox/server/postgresql/utils/query.py
+++ b/src/matchbox/server/postgresql/utils/query.py
@@ -1,14 +1,16 @@
 """Utilities for querying and matching in the PostgreSQL backend."""
 
 from collections import defaultdict
-from typing import Literal
 
 import pyarrow as pa
-from sqlalchemy import and_, func, join, literal_column, select
+from sqlalchemy import literal_column, select
 from sqlalchemy.orm import Session
-from sqlalchemy.sql.elements import ColumnElement
-from sqlalchemy.sql.selectable import CTE, Select, Subquery
 
+from matchbox.common.adapters.sql.query import (
+    build_matching_leaves_cte,
+    build_target_cluster_cte,
+    build_unified_query,
+)
 from matchbox.common.db import sql_to_df
 from matchbox.common.dtos import (
     Match,
@@ -25,156 +27,10 @@ from matchbox.common.logging import logger
 from matchbox.server.postgresql.db import MBDB
 from matchbox.server.postgresql.orm import (
     ClusterSourceKey,
-    Contains,
-    ResolverClusters,
     SourceConfigs,
     Steps,
 )
 from matchbox.server.postgresql.utils.db import compile_sql
-
-
-def _build_unified_query(
-    step: Steps,
-    sources: list[SourceConfigs] | None = None,
-    level: Literal["leaf", "key"] = "leaf",
-    include_source_config_id: bool = False,
-) -> Select:
-    """Build a query that projects records to root IDs through the hierarchy."""
-    lineage = step.get_lineage(sources=sources, queryable_only=True)
-
-    # Separate lineage entries into resolver steps and source config IDs.
-    # Entries without a source_config_id are resolver nodes, the rest are sources
-    resolver_ids: list[int] = []
-    source_config_ids: list[int] = []
-    for step_id, source_config_id in lineage:
-        if source_config_id is None:
-            resolver_ids.append(step_id)
-        else:
-            source_config_ids.append(source_config_id)
-
-    # ClusterSourceKey is the base table, resolver subqueries are LEFT JOINed onto it
-    from_clause = ClusterSourceKey
-    projected_roots: list[ColumnElement[int]] = []
-
-    for resolver_id in resolver_ids:
-        # For each resolver, build a subquery that maps leaf cluster IDs to their
-        # root cluster IDs at that step level via the Contains table.
-        assignments: Subquery = (
-            select(
-                Contains.leaf.label("leaf_id"),
-                Contains.root.label("root_id"),
-            )
-            .select_from(Contains)
-            .join(
-                ResolverClusters,
-                and_(
-                    ResolverClusters.cluster_id == Contains.root,
-                    ResolverClusters.step_id == resolver_id,
-                ),
-            )
-            .subquery(f"resolver_assignments_{resolver_id}")
-        )
-        # LEFT JOIN so that records not claimed by this resolver are still returned
-        from_clause = join(
-            from_clause,
-            assignments,
-            assignments.c.leaf_id == ClusterSourceKey.cluster_id,
-            isouter=True,
-        )
-        projected_roots.append(assignments.c.root_id)
-
-    # COALESCE across all resolver root columns
-    # First non-null wins, giving higher-priority resolvers precedence
-    # Falls back to the source cluster ID when no resolver has claimed the record
-    root_projection: ColumnElement[int] = (
-        func.coalesce(*projected_roots, ClusterSourceKey.cluster_id)
-        if projected_roots
-        else ClusterSourceKey.cluster_id
-    )
-
-    selection: list[ColumnElement] = [
-        root_projection.label("root_id"),
-        ClusterSourceKey.cluster_id.label("leaf_id"),
-    ]
-    if level == "key":
-        # "key" level adds the source key, producing more rows than "leaf" because
-        # multiple keys can share the same leaf cluster
-        selection.append(ClusterSourceKey.key)
-    if include_source_config_id:
-        selection.append(ClusterSourceKey.source_config_id.label("source_config_id"))
-
-    query_stmt = (
-        select(*selection)
-        .select_from(from_clause)
-        .where(ClusterSourceKey.source_config_id.in_(source_config_ids))
-    )
-
-    # At "leaf" level, deduplicate rows introduced because multiple keys share
-    # the same leaf cluster
-    if level == "leaf":
-        query_stmt = query_stmt.distinct()
-
-    return query_stmt
-
-
-def _build_target_cluster_cte(
-    key: str,
-    source_config_id: int,
-    step: Steps,
-) -> CTE:
-    """Build the target cluster CTE for a source key."""
-    # Reuse the unified query at key level, filtered to this source config,
-    # so we get the resolved root cluster for the given key
-    source_projection = _build_unified_query(
-        step=step,
-        level="key",
-        include_source_config_id=True,
-    ).subquery("source_projection")
-
-    return (
-        select(source_projection.c.root_id.label("cluster_id"))
-        .where(
-            and_(
-                source_projection.c.source_config_id == source_config_id,
-                source_projection.c.key == key,
-            )
-        )
-        # Exactly one cluster per key
-        # LIMIT 1 avoids a redundant scan
-        .limit(1)
-        .cte("target_cluster")
-    )
-
-
-def _build_matching_leaves_cte(
-    source_and_target_ids: list[int],
-    step: Steps,
-    target_cluster_cte: CTE,
-) -> CTE:
-    """Build the matching keys CTE for a resolved cluster."""
-    # Project all source + target keys through the hierarchy, then filter to those
-    # whose resolved root matches the target cluster
-    full_projection = _build_unified_query(
-        step=step,
-        level="key",
-        include_source_config_id=True,
-    ).subquery("full_projection")
-
-    return (
-        select(
-            full_projection.c.root_id.label("cluster_id"),
-            full_projection.c.source_config_id,
-            full_projection.c.key,
-        )
-        .where(
-            and_(
-                full_projection.c.source_config_id.in_(source_and_target_ids),
-                full_projection.c.root_id == target_cluster_cte.c.cluster_id,
-            )
-        )
-        .distinct()
-        .cte("matching_leaves")
-    )
 
 
 def require_complete_resolver(
@@ -192,32 +48,6 @@ def require_complete_resolver(
     if resolver_step.upload_stage != UploadStage.COMPLETE:
         raise MatchboxStepNotQueriable
     return resolver_step
-
-
-def resolver_membership_subquery(
-    step_id: int,
-    alias: str = "resolver_membership",
-) -> Subquery:
-    """Build root_id/leaf_id membership rows for a resolver."""
-    # First branch: root clusters count as their own leaf (self-membership)
-    roots_query = select(
-        ResolverClusters.cluster_id.label("root_id"),
-        ResolverClusters.cluster_id.label("leaf_id"),
-    ).where(ResolverClusters.step_id == step_id)
-
-    # Second branch: all clusters contained within a root via the Contains table
-    leaves_query = (
-        select(
-            ResolverClusters.cluster_id.label("root_id"),
-            Contains.leaf.label("leaf_id"),
-        )
-        .select_from(ResolverClusters)
-        .join(Contains, Contains.root == ResolverClusters.cluster_id)
-        .where(ResolverClusters.step_id == step_id)
-    )
-
-    # UNION deduplicates in case a root cluster also appears as a leaf
-    return roots_query.union(leaves_query).subquery(alias)
 
 
 def query(
@@ -244,9 +74,9 @@ def query(
         if step.upload_stage != UploadStage.COMPLETE:
             raise MatchboxStepNotQueriable
 
-        query_stmt = _build_unified_query(
-            step=step,
-            sources=[source_config],
+        lineage = step.get_lineage(sources=[source_config], queryable_only=True)
+        query_stmt = build_unified_query(
+            lineage=lineage,
             level="key",
             include_source_config_id=False,
         )
@@ -302,16 +132,19 @@ def match(
             *(tc.source_config_id for tc in target_configs),
         ]
 
-        # Resolve which cluster this key belongs to according to the resolver
-        target_cluster_cte = _build_target_cluster_cte(
+        # Resolve which cluster this key belongs to according to the resolver.
+        # Lineage is unfiltered (no sources) and shared by both CTEs below
+        lineage = resolver_step.get_lineage(queryable_only=True)
+
+        target_cluster_cte = build_target_cluster_cte(
             key=key,
             source_config_id=source_config.source_config_id,
-            step=resolver_step,
+            lineage=lineage,
         )
 
-        matching_leaves_cte = _build_matching_leaves_cte(
+        matching_leaves_cte = build_matching_leaves_cte(
             source_and_target_ids=source_and_target_ids,
-            step=resolver_step,
+            lineage=lineage,
             target_cluster_cte=target_cluster_cte,
         )
 

--- a/test/fixtures/db.py
+++ b/test/fixtures/db.py
@@ -462,9 +462,14 @@ def upload_tracker_redis(
 
 # Backends
 
-BACKENDS = [
+SERVER_BACKENDS = [
     pytest.param("matchbox_postgres", id="postgres"),
 ]
+
+LOCAL_BACKENDS: list = []
+# TODO: populate once the local duckdb adapter lands
+
+CLUSTER_STORES = SERVER_BACKENDS + LOCAL_BACKENDS
 
 
 @pytest.fixture(scope="function")

--- a/test/server/adapter/test_adapter_admin.py
+++ b/test/server/adapter/test_adapter_admin.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import pytest
 from sqlalchemy import Engine
-from test.fixtures.db import BACKENDS
+from test.fixtures.db import SERVER_BACKENDS
 
 from matchbox.common.dtos import (
     BackendResourceType,
@@ -29,7 +29,7 @@ from matchbox.common.factories.scenarios import setup_scenario
 from matchbox.server.base import MatchboxDBAdapter
 
 
-@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("backend", SERVER_BACKENDS)
 @pytest.mark.docker
 class TestMatchboxAdminBackend:
     @pytest.fixture(autouse=True)

--- a/test/server/adapter/test_adapter_collections.py
+++ b/test/server/adapter/test_adapter_collections.py
@@ -5,7 +5,7 @@ from functools import partial
 import pyarrow as pa
 import pytest
 from sqlalchemy import Engine
-from test.fixtures.db import BACKENDS
+from test.fixtures.db import SERVER_BACKENDS
 
 from matchbox.client.queries import Query
 from matchbox.common.datatypes import DataTypes
@@ -41,7 +41,7 @@ from matchbox.common.factories.sources import SourceTestkit
 from matchbox.server.base import MatchboxDBAdapter
 
 
-@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("backend", SERVER_BACKENDS)
 @pytest.mark.docker
 class TestMatchboxCollectionsBackend:
     @pytest.fixture(autouse=True)

--- a/test/server/adapter/test_adapter_eval.py
+++ b/test/server/adapter/test_adapter_eval.py
@@ -6,7 +6,7 @@ import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
 from sqlalchemy import Engine
-from test.fixtures.db import BACKENDS
+from test.fixtures.db import SERVER_BACKENDS
 
 from matchbox.common.arrow import (
     SCHEMA_CLUSTER_EXPANSION,
@@ -23,7 +23,7 @@ from matchbox.common.factories.scenarios import setup_scenario
 from matchbox.server.base import MatchboxDBAdapter
 
 
-@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("backend", SERVER_BACKENDS)
 @pytest.mark.docker
 class TestMatchboxEvaluationBackend:
     @pytest.fixture(autouse=True)

--- a/test/server/adapter/test_adapter_groups.py
+++ b/test/server/adapter/test_adapter_groups.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import pytest
 from sqlalchemy import Engine
-from test.fixtures.db import BACKENDS
+from test.fixtures.db import SERVER_BACKENDS
 
 from matchbox.common.dtos import (
     DefaultGroup,
@@ -23,7 +23,7 @@ from matchbox.common.factories.scenarios import setup_scenario
 from matchbox.server.base import MatchboxDBAdapter
 
 
-@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("backend", SERVER_BACKENDS)
 @pytest.mark.docker
 class TestMatchboxGroupsBackend:
     @pytest.fixture(autouse=True)

--- a/test/server/adapter/test_adapter_main.py
+++ b/test/server/adapter/test_adapter_main.py
@@ -4,13 +4,13 @@ from functools import partial
 
 import pytest
 from sqlalchemy import Engine
-from test.fixtures.db import BACKENDS
+from test.fixtures.db import SERVER_BACKENDS
 
 from matchbox.common.factories.scenarios import setup_scenario
 from matchbox.server.base import MatchboxDBAdapter
 
 
-@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("backend", SERVER_BACKENDS)
 @pytest.mark.docker
 class TestMatchboxMainBackend:
     @pytest.fixture(autouse=True)

--- a/test/server/adapter/test_adapter_query.py
+++ b/test/server/adapter/test_adapter_query.py
@@ -6,7 +6,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 from sqlalchemy import Engine
-from test.fixtures.db import BACKENDS
+from test.fixtures.db import SERVER_BACKENDS
 
 from matchbox.common.arrow import SCHEMA_QUERY, SCHEMA_QUERY_WITH_LEAVES
 from matchbox.common.dtos import Match
@@ -15,7 +15,7 @@ from matchbox.common.factories.scenarios import setup_scenario
 from matchbox.server.base import MatchboxDBAdapter
 
 
-@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("backend", SERVER_BACKENDS)
 @pytest.mark.docker
 class TestMatchboxQueryBackend:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Part of #560. Covers PRs A-C.

A local adapter and a server adapter will have some common machinery, and some distinct. This factors out the common stuff, and refactors unit tests so they can cover both types of adapter.

## 🛠️ Changes proposed in this pull request

Moves common SQLAlchemy tables and functions into `common`, then uses them in the PostgreSQL adapter.

With the tables, we use the [Declarative with Imperative Table (Hybrid Declarative) pattern](https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html#declarative-with-imperative-table-a-k-a-hybrid-declarative) so we have shared table definitions that can be used in different databases.

A side effect of this is we have one shared symbolic `"mb"` metadata plus `schema_translate_map` at the engine. I've commented it when it's present as it's confusing to see at a low level.

I appreciate the diff is hard when it's 90% lift and shift, so these are the ways in which the moved functions differ:

* Lineage computed by the caller now (`step.get_lineage()`), builders take it as a plain argument instead of calling it themselves internally.
* `match()` computes lineage once and reuses it for both CTEs; originally each CTE independently recomputed identical lineage via two DB round trips.
* `_compute_resolver_hashes` split into three pieces: `build_expanded_leaves_subquery`, a new `build_leaf_hash_groups_query`, and pure-Python `hash_resolver_parents`.
* `hash_resolver_parents` takes `Iterable[Row]` not `Iterable[tuple[int, Iterable[bytes]]]`
* `clear_database()` schema lookup fixed: `self.MatchboxBase.metadata.schema` (now symbolic) swapped for `self.settings.postgres.db_schema`

## 👀 Guidance to review

Are you happy with the high level SQLAlchemy pattern I've used? Alternatives were to make factories, but I like this better. I've also gone with classlike var names which technically violates PEP8 but I think reads way nicer.

## 🤖 AI declaration

AI written, human reviewed.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
