### PR TITLE
fix: make resolver priority deterministic

### DIFF
--- a/src/matchbox/server/postgresql/orm.py
+++ b/src/matchbox/server/postgresql/orm.py
@@ -330,7 +330,7 @@ class Steps(CountMixin, MBDB.MatchboxBase):
     ) -> list[tuple[int, int | None]]:
         """Returns lineage ordered by priority.
 
-        Highest priority (lowest level) first, then by step_id for stability.
+        Highest priority (lowest level) first, then by step name for stability.
 
         Args:
             sources: If provided, only return lineage paths that lead to these sources
@@ -386,7 +386,7 @@ class Steps(CountMixin, MBDB.MatchboxBase):
                 )
 
             results = session.execute(
-                query.order_by(StepFrom.level.asc(), StepFrom.parent.asc())
+                query.order_by(StepFrom.level.asc(), Steps.name.collate("C").asc())
             ).all()
 
             # Get self's source config ID


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

Resolver priority for steps at the same lineage depth was ordered by `step_id`. Since step IDs are assigned during insertion, equivalent runs could produce different resolver priorities.

Order equal-depth steps by name using PostgreSQL's `C` collation instead. Since step names are restricted to ASCII characters, it should agree with Python's lexical ordering and give the "server-less" portability that https://github.com/uktrade/matchbox/issues/560 requires.

Lineage depth remains the primary ordering criterion.

Closes [#612](https://github.com/uktrade/matchbox/issues/612).

## 🤖 AI declaration

None

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
