### PR TITLE
fix: prevent idle transactions in the ADBC pool

### DIFF
--- a/src/matchbox/server/postgresql/db.py
+++ b/src/matchbox/server/postgresql/db.py
@@ -4,7 +4,7 @@ import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from adbc_driver_postgresql import dbapi as adbc_dbapi
 from adbc_driver_postgresql.dbapi import Connection as AdbcConnection
@@ -19,6 +19,7 @@ from sqlalchemy import (
     create_engine,
     text,
 )
+from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.pool import QueuePool
 
@@ -80,7 +81,6 @@ class MatchboxDatabase:
         self._SessionLocal: sessionmaker | None = None
         self._adbc_pool: QueuePool | None = None
         self._adbc_lock = threading.Lock()
-        self._source_adbc_connection: adbc_dbapi.Connection | None = None
         self.MatchboxBase = declarative_base(
             metadata=MetaData(schema=settings.postgres.db_schema)
         )
@@ -113,20 +113,20 @@ class MatchboxDatabase:
             self._SessionLocal = None
 
     def _connect_adbc(self) -> None:
-        self._source_adbc_connection = adbc_dbapi.connect(
-            self.connection_string(driver=False)
-        )
+        # adbc clones default to non-autocommit and stay idle in transaction
         self._adbc_pool = QueuePool(
-            self._source_adbc_connection.adbc_clone,
+            lambda: cast(
+                DBAPIConnection,
+                adbc_dbapi.connect(
+                    self.connection_string(driver=False), autocommit=True
+                ),
+            ),
         )
 
     def _disconnect_adbc(self) -> None:
         if self._adbc_pool:
             self._adbc_pool.dispose()
             self._adbc_pool = None
-
-            self._source_adbc_connection.close()
-            self._source_adbc_connection = None
 
     @contextmanager
     def settings_scope(
@@ -188,9 +188,8 @@ class MatchboxDatabase:
 
         try:
             yield connection
-            connection.commit()
-        except BaseException:
-            connection.rollback()
+        except adbc_dbapi.Error as exc:
+            pool.invalidate(exc)
             raise
         finally:
             pool.close()

--- a/test/server/postgresql/test_pg_core.py
+++ b/test/server/postgresql/test_pg_core.py
@@ -1,11 +1,37 @@
 import pyarrow as pa
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.dialects.postgresql import BIGINT, TEXT
 
 from matchbox.server.postgresql import MatchboxPostgres
 from matchbox.server.postgresql.db import MBDB
 from matchbox.server.postgresql.utils.db import ingest_to_temporary_table
+
+
+@pytest.mark.docker
+def test_adbc_pool_state(matchbox_postgres: MatchboxPostgres) -> None:
+    """Ensure pooled ADBC connections do not retain open transactions.
+
+    ADBC starts a new transaction after commit or rollback when autocommit is
+    disabled. PostgreSQL can terminate a connection returned in that state when
+    it reaches the idle-in-transaction timeout, so pooled connections must be idle.
+    """
+    with (
+        MBDB.get_adbc_connection() as connection,
+        connection.cursor() as cursor,
+    ):
+        cursor.execute("SELECT pg_backend_pid()")
+        row = cursor.fetchone()
+        assert row is not None
+        backend_pid = row[0]
+
+    with MBDB.get_session() as session:
+        state = session.execute(
+            text("SELECT state FROM pg_stat_activity WHERE pid = :pid"),
+            {"pid": backend_pid},
+        ).scalar_one()
+
+    assert state == "idle"
 
 
 @pytest.mark.docker


### PR DESCRIPTION
## 🛠️ Changes proposed in this pull request

ADBC disables auto-commit by default and immediately starts another transaction after commit or rollback. Returning those connections to the pool leaves every connection idle in transaction. PostgreSQL eventually terminates those connections when `idle_in_transaction_session_timeout` is reached.

Create each physical pool connection directly with auto-commit enabled instead of cloning a transactional source connection. Invalidate pool entries that raise ADBC errors so terminated connections are not reused. Matchbox’s normal SQLAlchemy sessions still use explicit transactions, i.e., the change only affects the ADBC pool and does not change the public API.

Fixes https://github.com/uktrade/matchbox/issues/616.

## 👀 Guidance to review

Running this on main against db shows the API's supposedly unused ADBC connections still have active transactions:

```sql
# you should see a bunch of these: state | idle in transaction
SELECT pid, state, xact_start, state_change, query FROM pg_stat_activity
WHERE datname = current_database() ORDER BY pid;
```

## 🤖 AI declaration

None.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
