### PR TITLE
Speed up the factory subsystem

### DIFF
--- a/src/matchbox/common/factories/entities.py
+++ b/src/matchbox/common/factories/entities.py
@@ -505,22 +505,42 @@ def generate_entities(
     n: int,
 ) -> tuple[SourceEntity]:
     """Generate base entities with their ground truth values from generator."""
-    entities = []
-    for _ in range(n):
-        base_values = {}
-        for feature in features:
-            generator_func = generator.unique if feature.unique else generator
-            value_generator = getattr(generator_func, feature.base_generator)
-            parameters = {} if not feature.parameters else dict(feature.parameters)
 
-            value = value_generator(**parameters)
-            # Explicitly cast lists to tuples to ensure they are hashable
-            if isinstance(value, list):
-                value = tuple(value)
-            base_values[feature.name] = value
+    def _batch(k: int, feature: FeatureConfig) -> list[Any]:
+        """Generate k values for a feature."""
+        value_generator = getattr(generator, feature.base_generator)
+        parameters = {} if not feature.parameters else dict(feature.parameters)
+        values = (value_generator(**parameters) for _ in range(k))
+        # Explicitly cast lists to tuples to ensure they are hashable
+        return [tuple(v) if isinstance(v, list) else v for v in values]
 
-        entities.append(SourceEntity(base_values=base_values, keys=EntityReference()))
-    return tuple(entities)
+    # Generate one column of values per feature. Uniqueness is enforced by
+    # generate-and-deduplicate, which is far faster than Faker's unique proxy.
+    columns: list[list[Any]] = []
+    for feature in features:
+        if not feature.unique:
+            columns.append(_batch(n, feature))
+            continue
+
+        unique_values: dict[Any, None] = {}  # dict preserves insertion order
+        for _ in range(1000):  # retry budget for collisions
+            if (shortfall := n - len(unique_values)) == 0:
+                break
+            for value in _batch(shortfall, feature):
+                unique_values.setdefault(value)
+        else:
+            raise RuntimeError(
+                f"Could not generate {n:,} unique values for feature {feature.name!r}"
+            )
+        columns.append(list(unique_values))
+
+    return tuple(
+        SourceEntity(
+            base_values=dict(zip((f.name for f in features), row, strict=True)),
+            keys=EntityReference(),
+        )
+        for row in zip(*columns, strict=True)
+    )
 
 
 def scores_to_results_entities(

--- a/src/matchbox/common/factories/sources.py
+++ b/src/matchbox/common/factories/sources.py
@@ -7,7 +7,6 @@ from itertools import product
 from math import prod
 from typing import Any, ParamSpec, Self, TypeVar
 
-import pandas as pd
 import polars as pl
 import pyarrow as pa
 from adbc_driver_manager.dbapi import Connection as AdbcConnection
@@ -403,18 +402,19 @@ def generate_rows(
     id_keys = {}
     id_hashes = {}
     value_to_id = {}
+    random = generator.random  # Faker's proxy is too slow for the hot loop
 
     def add_row(entity_id: int, values: tuple) -> None:
         """Add a row of data, handling IDs and keys."""
-        key = str(generator.uuid4())
+        # Cheaper than generator.uuid4()
+        key = f"{random.getrandbits(128):032x}"
         entity_keys[entity_id].append(key)
-        row_hash = hash_values(*(str(v) for v in values))
 
         if values not in value_to_id:
-            mb_id = generator.random_number(digits=16)
+            mb_id = random.getrandbits(63)
             value_to_id[values] = mb_id
             id_keys[mb_id] = []
-            id_hashes[mb_id] = row_hash
+            id_hashes[mb_id] = hash_values(*(str(v) for v in values))
 
         row_id = value_to_id[values]
         id_keys[row_id].append(key)
@@ -494,9 +494,6 @@ def generate_source(
         repetition=repetition,
     )
 
-    # Create DataFrame
-    df = pd.DataFrame(raw_data)
-
     # Create hash groups
     keys = []
     hashes = []
@@ -513,14 +510,16 @@ def generate_source(
     )
 
     # Update variation counts
+    key_to_id = dict(zip(raw_data["key"], raw_data["id"], strict=True))
     for entity in selected_entities:
         if entity.id in entity_keys:
             # Count unique row IDs this entity appears in
-            entity_rows = df[df["key"].isin(entity_keys[entity.id])]
-            entity.total_unique_variations = len(set(entity_rows["id"]))
+            entity.total_unique_variations = len(
+                {key_to_id[key] for key in entity_keys[entity.id]}
+            )
 
     return (
-        pa.Table.from_pandas(df, preserve_index=False),
+        pa.table(raw_data),
         data_hashes,
         entity_keys,
         id_keys,
@@ -558,7 +557,9 @@ def source_factory(
         repetition: Number of times to repeat the generated data. Defaults to 0.
         seed: Random seed for reproducibility. Defaults to 42.
     """
-    generator = Faker()
+    # Weighted sampling is much slower and causes heavy collision-driven
+    # retries when generating unique values at scale
+    generator = Faker(use_weighting=False)
     generator.seed_instance(seed)
 
     if features is None:
@@ -644,7 +645,7 @@ def source_factory(
         features=features,
         data=data,
         data_hashes=data_hashes,
-        entities=tuple(sorted(results_entities)),
+        entities=tuple(sorted(results_entities, key=lambda e: e.id)),
     )
 
 
@@ -658,7 +659,9 @@ def source_from_tuple(
     seed: int = 42,
 ) -> SourceTestkit:
     """Generate a complete source testkit from dummy data."""
-    generator = Faker()
+    # Weighted sampling is much slower and causes heavy collision-driven
+    # retries when generating unique values at scale
+    generator = Faker(use_weighting=False)
     generator.seed_instance(seed)
 
     if name is None:
@@ -732,7 +735,7 @@ def source_from_tuple(
         source=source,
         data=data,
         data_hashes=data_hashes,
-        entities=tuple(sorted(results_entities)),
+        entities=tuple(sorted(results_entities, key=lambda e: e.id)),
     )
 
 
@@ -941,7 +944,7 @@ def linked_sources_factory(
             features=tuple(parameters.features),
             data=data,
             data_hashes=data_hashes,
-            entities=tuple(sorted(results_entities)),
+            entities=tuple(sorted(results_entities, key=lambda e: e.id)),
         )
 
         # Update entities with source references


### PR DESCRIPTION
I want to use the factory subsystem to test some of the speedup ideas discussed in #560.

These are small, targeted changes that I hope are easy to review, but extremely impactful on our ability to scale this data.

## 🛠️ Changes proposed in this pull request

* Killed an `O(n²)` pandas filter in the row-count loop, replacing it with a dict lookup
* Turned off Faker's weighted sampling and swapped its unique proxy for batched generate-and-deduplicate
* Trimmed per-row overhead: direct seeded randoms for keys/ids, hash only new content, skip pandas and pydantic in bulk construction

## 👀 Guidance to review

I used a small script to test speeds, centered around `linked_sources_factory(n_true_entities=n)`.

Before edits:

entities | rows | seconds | rows/s
-- | -- | -- | --
50 | 325 | 0.09 | 3,611
500 | 3,250 | 0.25 | 12,929
5,000 | 32,500 | 3.58 | 9,078
50,000 | 325,000 | 139.89 | 2,323

After edits:

| entities | rows | seconds | rows/s |
|---|---|---|---|
| 50 | 325 | 0.06 | 5,606 |
| 500 | 3,250 | 0.09 | 35,143 |
| 5,000 | 32,500 | 1.12 | 29,059 |
| 50,000 | 325,000 | 13.33 | 24,379 |

## 🤖 AI declaration

Heavy use of AI to both ideate, implement and the test script. Human reviewed.

## ✅ Checklist:

- [x] This is the smallest, simplest solution to the problem
- [x] I've read [our code standards](https://uktrade.github.io/matchbox/contributing/) and this code follows them  
- [x] All new code is tested
- I've updated all relevant documentation (select all that apply)
    - [x] API documentation (docstrings and indexes)
    - [ ] Tutorials
    - [ ] Developer docs
